### PR TITLE
Sigmoid function

### DIFF
--- a/larndsim/consts_ep.py
+++ b/larndsim/consts_ep.py
@@ -8,6 +8,9 @@ import torch
 
 class consts:
     def __init__(self):
+        ## Turn smoothing on/off to help gradients
+        self.smooth = True
+
         ## Detector constants
         #: Liquid argon density in :math:`g/cm^3`
         self.lArDensity = 1.38 # g/cm^3

--- a/larndsim/detsim_ep.py
+++ b/larndsim/detsim_ep.py
@@ -141,8 +141,11 @@ class detsim(consts):
     def cdf(self, x):
         return 1/2 * (1 + self.erf_hack(x/np.sqrt(2)))
 
-    def skew_normal(self, x, alpha):
-        return 2*self.normal(x, 0, 1)*self.cdf(alpha*x)
+    def skew_normal(self, x, alpha, sigma=1):
+        return 2*self.normal(x, 0, sigma)*self.cdf(alpha*x)
+
+    def sigmoid(self, x):
+        return 1. / (1 + ep.exp(-x))
 
     def rho(self, point, q, start, sigmas, segment):
         """
@@ -207,8 +210,10 @@ class detsim(consts):
         y = ep.maximum(y, -10.)
         #Make everything positive and then mask to avoid infs
         #return (ep.exp(-ep.abs(y)) * (y>0)) / scale
-        return 1.25*self.skew_normal(y, 100)
+        #return 1.25*self.skew_normal(y, 100)
+        #return 25.0663*self.skew_normal(y, 1000, sigma=20)*ep.exp(-y)
         #return (ep.sign(y)+1) / 2. * ep.exp(-y) / scale #* STEFunction.apply(y.raw)
+        return self.sigmoid(40*y)*ep.exp(-y) / scale
         #return ep.exp(-y) / scale
 
     def current_model(self, t, t0, x, y):

--- a/larndsim/detsim_ep.py
+++ b/larndsim/detsim_ep.py
@@ -296,7 +296,7 @@ class detsim(consts):
 
         z_sampling = self.t_sampling / 2.
         z_steps = ep.maximum(self.sampled_points, ((ep.abs(z_end_int
-                                                    - z_start_int) / z_sampling)+1.).astype(int))
+                                                    - z_start_int) / z_sampling)+1).astype(int))
 
         z_step = (z_end_int - z_start_int) / (z_steps - 1)
 

--- a/larndsim/detsim_ep.py
+++ b/larndsim/detsim_ep.py
@@ -11,8 +11,6 @@ from torch.utils import checkpoint
 from .consts_ep import consts
 from .fee_ep import fee
 
-import torch.nn.functional as F
-
 import logging
 
 logging.basicConfig()
@@ -298,7 +296,7 @@ class detsim(consts):
 
         z_sampling = self.t_sampling / 2.
         z_steps = ep.maximum(self.sampled_points, ((ep.abs(z_end_int
-                                                    - z_start_int) / z_sampling)+1.))
+                                                    - z_start_int) / z_sampling)+1.).astype(int))
 
         z_step = (z_end_int - z_start_int) / (z_steps - 1)
 

--- a/larndsim/utils.py
+++ b/larndsim/utils.py
@@ -1,0 +1,14 @@
+import eagerpy as ep
+
+def diff_linspace(start, end, num, endpoint=False):
+    start = ep.astensor(start)
+    end = ep.astensor(end)
+    num = int(num)
+    
+    delta = (end - start) / num
+    if endpoint:
+        delta *= num / (num - 1)
+    return start + ep.arange(end, 0, num)*delta
+
+def diff_arange(start, end):
+    return ep.flip(ep.stack([end-j-1. for j in range((end-start).astype(int).item())]), axis=0)

--- a/optimize/utils.py
+++ b/optimize/utils.py
@@ -53,7 +53,7 @@ def all_sim(sim, selected_tracks, fields, event_id_map, unique_eventIDs, return_
 
     unique_pix_torch = torch.empty((0, 2), device=neighboring_pixels_torch.device)
     pixels_signals_torch = torch.zeros((len(unique_pix_torch), len(sim.time_ticks)*50),
-                                       device=unique_pix_torch.device)
+                                       device=unique_pix_torch.device, dtype=selected_tracks.dtype)
 
     shapes_torch = neighboring_pixels_torch.shape
     joined_torch = neighboring_pixels_torch.reshape(shapes_torch[0]*shapes_torch[1], 2)


### PR DESCRIPTION
Add in sigmoid function as discussed [here](https://indico.slac.stanford.edu/event/7170/contributions/3667/attachments/1554/4064/Differentiability%20of%20Sim%20Pieces.pdf). Includes a switch between smooth and not smoothed versions of simulation, with ~ reasonable defaults set.

Some small additional edits: make types match in `all_sim`, pass vdrift as an argument to checkpointed function to allow gradient flow to work, add differentiable versions of arange and linspace to a utils.py (but these don't seem to matter (?) so not used anywhere).