### PR TITLE
Noiseless guess

### DIFF
--- a/optimize/example_run.py
+++ b/optimize/example_run.py
@@ -14,10 +14,13 @@ def main(config):
                                   shuffle=config.data_shuffle, 
                                   batch_size=config.batch_sz,
                                   pin_memory=True, num_workers=config.num_workers)
+
     param_fit = ParamFitter(config.param_list, dataset.get_track_fields(),
                             track_chunk=config.track_chunk, pixel_chunk=config.pixel_chunk,
                             detector_props=config.detector_props, pixel_layouts=config.pixel_layouts,
-                            load_checkpoint=config.load_checkpoint, lr=config.lr, readout_noise=(not config.no_noise))
+                            load_checkpoint=config.load_checkpoint, lr=config.lr, 
+                            readout_noise_target=(not config.no_noise) and (not config.no_noise_target),
+                            readout_noise_guess=(not config.no_noise) and (not config.no_noise_guess))
     param_fit.make_target_sim(seed=config.seed)
     param_fit.fit(tracks_dataloader, epochs=config.epochs, shuffle=config.data_shuffle)
 
@@ -57,7 +60,11 @@ if __name__ == '__main__':
     parser.add_argument("--data_sz", dest="data_sz", default=5, type=int,
                         help="data size for fitting (number of tracks)")
     parser.add_argument("--no-noise", dest="no_noise", default=False, action="store_true",
-                        help="Flag to turn off readout noise")
+                        help="Flag to turn off readout noise (both target and guess)")
+    parser.add_argument("--no-noise-target", dest="no_noise_target", default=False, action="store_true",
+                        help="Flag to turn off readout noise (just target, guess has noise)")
+    parser.add_argument("--no-noise-guess", dest="no_noise_guess", default=False, action="store_true",
+                        help="Flag to turn off readout noise (just guess, target has noise)")
     parser.add_argument("--data_shuffle", dest="data_shuffle", default=False, action="store_true",
                         help="Flag of data shuffling")
     parser.add_argument("--random_ntrack", dest="random_ntrack", default=False, action="store_true",

--- a/optimize/example_run.py
+++ b/optimize/example_run.py
@@ -15,6 +15,8 @@ def main(config):
                                   batch_size=config.batch_sz,
                                   pin_memory=True, num_workers=config.num_workers)
 
+    # For readout noise: no_noise overrides if explicitly set to True. Otherwise, turn on noise
+    # individually for target and guess
     param_fit = ParamFitter(config.param_list, dataset.get_track_fields(),
                             track_chunk=config.track_chunk, pixel_chunk=config.pixel_chunk,
                             detector_props=config.detector_props, pixel_layouts=config.pixel_layouts,

--- a/optimize/fit_params.py
+++ b/optimize/fit_params.py
@@ -14,7 +14,7 @@ from tqdm import tqdm
 class ParamFitter:
     def __init__(self, relevant_params, track_fields, track_chunk, pixel_chunk,
                  detector_props, pixel_layouts, load_checkpoint = None,
-                 lr=None, optimizer=None, loss_fn=None, readout_noise=True):
+                 lr=None, optimizer=None, loss_fn=None, readout_noise_target=True, readout_noise_guess=False):
 
         # If you have access to a GPU, sim works trivially/is much faster
         if torch.cuda.is_available():
@@ -38,11 +38,11 @@ class ParamFitter:
             is_continue = True
 
         # Simulation object for target
-        self.sim_target = sim_with_grad(track_chunk=track_chunk, pixel_chunk=pixel_chunk, readout_noise=readout_noise)
+        self.sim_target = sim_with_grad(track_chunk=track_chunk, pixel_chunk=pixel_chunk, readout_noise=readout_noise_target)
         self.sim_target.load_detector_properties(detector_props, pixel_layouts)
 
         # Simulation object for iteration -- this is where gradient updates will happen
-        self.sim_iter = sim_with_grad(track_chunk=track_chunk, pixel_chunk=pixel_chunk, readout_noise=readout_noise)
+        self.sim_iter = sim_with_grad(track_chunk=track_chunk, pixel_chunk=pixel_chunk, readout_noise=readout_noise_guess)
         self.sim_iter.load_detector_properties(detector_props, pixel_layouts)
 
         # Normalize parameters to init at 1, or set to checkpointed values
@@ -56,7 +56,7 @@ class ParamFitter:
         self.sim_iter.track_gradients(self.relevant_params_list)
 
         # Placeholder simulation -- parameters will be set by un-normalizing sim_iter
-        self.sim_physics = sim_with_grad(track_chunk=track_chunk, pixel_chunk=pixel_chunk, readout_noise=readout_noise)
+        self.sim_physics = sim_with_grad(track_chunk=track_chunk, pixel_chunk=pixel_chunk, readout_noise=readout_noise_guess)
         self.sim_physics.load_detector_properties(detector_props, pixel_layouts)
 
         # Set up optimizer -- can pass in directly, or construct as SGD from relevant params and/or lr


### PR DESCRIPTION
Split `readout_noise` flag into `readout_noise_target` and `readout_noise_guess` in `ParamFitter`. Note that in `sim_with_grad` objects, still just one `readout_noise` argument.

In `example_run`, running with `--no-noise` always has no noise in either. To switch off target/guess individually, use `--no-noise-target` and/or `--no-noise-guess` (without `--no-noise` flag). Using none of the flags has noise on everything.