### PR TITLE
Batch by Total dx

### DIFF
--- a/optimize/dataio.py
+++ b/optimize/dataio.py
@@ -13,7 +13,7 @@ def structured_from_torch(tracks_torch, dtype):
     return rfn.unstructured_to_structured(tracks_torch.cpu().numpy(), dtype=dtype)
 
 class TracksDataset(Dataset):
-    def __init__(self, filename, ntrack, swap_xz=True, seed=3, random_ntrack=False, track_zlen_sel=0., 
+    def __init__(self, filename, ntrack, swap_xz=True, seed=3, random_ntrack=False, track_zlen_sel=2., 
                  track_z_bound=28., max_batch_len=None):
 
         with h5py.File(filename, 'r') as f:

--- a/optimize/dataio.py
+++ b/optimize/dataio.py
@@ -13,7 +13,7 @@ def structured_from_torch(tracks_torch, dtype):
     return rfn.unstructured_to_structured(tracks_torch.cpu().numpy(), dtype=dtype)
 
 class TracksDataset(Dataset):
-    def __init__(self, filename, ntrack, max_nbatch, swap_xz=True, seed=3, random_ntrack=False, track_len_sel=2., 
+    def __init__(self, filename, ntrack, max_nbatch=None, swap_xz=True, seed=3, random_ntrack=False, track_len_sel=2., 
                  track_z_bound=28., max_batch_len=None, print_input=False):
 
         with h5py.File(filename, 'r') as f:
@@ -102,7 +102,7 @@ class TracksDataset(Dataset):
                         ev_here = []
                         trk_here = []
                         tot_length = 0
-                        if len(batches) >= max_nbatch and max_nbatch is not None and max_nbatch > 0: 
+                        if max_nbatch is not None and len(batches) >= max_nbatch and max_nbatch > 0: 
                             done_track_looping = True
                             break
                         batch_here.append(segment)

--- a/optimize/dataio.py
+++ b/optimize/dataio.py
@@ -13,8 +13,8 @@ def structured_from_torch(tracks_torch, dtype):
     return rfn.unstructured_to_structured(tracks_torch.cpu().numpy(), dtype=dtype)
 
 class TracksDataset(Dataset):
-    def __init__(self, filename, ntrack, swap_xz=True, seed=3, random_ntrack=False, track_zlen_sel=2., 
-                 track_z_bound=28., max_batch_len=None):
+    def __init__(self, filename, ntrack, max_nbatch, swap_xz=True, seed=3, random_ntrack=False, track_len_sel=2., 
+                 track_z_bound=28., max_batch_len=None, print_input=False):
 
         with h5py.File(filename, 'r') as f:
             tracks = np.array(f['segments'])
@@ -43,21 +43,23 @@ class TracksDataset(Dataset):
                 trk_msk = (tracks['eventID'] == ev) & (tracks['trackID'] == trk)
                 #TODO once we enter the end game, this track selection requirement needs to be more accessible.
                 # For now, we keep it as it is to take consistent data among developers
-                if max(tracks[trk_msk]['z']) - min(tracks[trk_msk]['z']) > track_zlen_sel and max(abs(tracks[trk_msk]['z'])) < track_z_bound:
+                if np.sum(tracks[trk_msk]['dx']) > track_len_sel and max(abs(tracks[trk_msk]['z'])) < track_z_bound:
                     index.append([ev, trk])
                     all_tracks.append(torch_from_structured(tracks[trk_msk]))
 
         # all fit with a sub-set of tracks
         fit_index = []
         fit_tracks = []
-        if ntrack >= len(index) or ntrack == -1:
+        random.seed(seed)
+        if ntrack is None or ntrack >= len(index) or ntrack <= 0:
+            if random_ntrack:
+                random.shuffle(all_tracks)
             fit_tracks = all_tracks
             fit_index = index
         else:
             # if the information of track index is uninteresting, then the next line + pad_sequence is enough
             # fit_tracks = random.sample(all_tracks, ntrack)
             if random_ntrack:
-                random.seed(seed)
                 list_rand = random.sample(range(len(index)), ntrack)
             else:
                 list_rand = np.arange(ntrack)
@@ -65,31 +67,61 @@ class TracksDataset(Dataset):
             for i_rand in list_rand:
                 fit_index.append(index[i_rand])
                 fit_tracks.append(all_tracks[i_rand])
-        
+
+        if print_input:
+            print("training set [ev, trk]: ", fit_index)
+      
         if max_batch_len is not None:
             batches = []
             batch_here = []
+            ev_here = []
+            trk_here = []
             tot_length = 0
+            tot_data_length = 0
+            done_track_looping = False
             for track in fit_tracks:
                 for segment in track:
+                    if segment[self.track_fields.index("dx")] > max_batch_len:
+                        continue
                     tot_length+=segment[self.track_fields.index("dx")]
                     if tot_length < max_batch_len:
                         batch_here.append(segment)
+                        ev_here.append(segment[[self.track_fields.index("eventID")]])
+                        trk_here.append(segment[[self.track_fields.index("trackID")]])
                     else:
-                        batches.append(torch.stack(batch_here))
+                       
+                        if len(batch_here) > 0:
+                            batches.append(torch.stack(batch_here))
+                            tot_data_length += tot_length - segment[self.track_fields.index("dx")]
+                            if print_input:
+                                print("~ [batch ID]: ", len(batches))
+                                print("  batch length: ", tot_length - segment[self.track_fields.index("dx")])
+                                print("  event IDs: ", ev_here)
+                                print("  track IDs: ", trk_here)
                         batch_here = []
+                        ev_here = []
+                        trk_here = []
                         tot_length = 0
-
+                        if len(batches) >= max_nbatch and max_nbatch is not None and max_nbatch > 0: 
+                            done_track_looping = True
+                            break
                         batch_here.append(segment)
+                        ev_here.append(segment[[self.track_fields.index("eventID")]])
+                        trk_here.append(segment[[self.track_fields.index("trackID")]])
                         tot_length+=segment[self.track_fields.index("dx")]
+                if done_track_looping:
+                    break
             if len(batch_here) > 0:
                 batches.append(torch.stack(batch_here))
+                tot_data_length += tot_length
             
             fit_tracks = batches
 
-        self.tracks = torch.nn.utils.rnn.pad_sequence(fit_tracks, batch_first=True, padding_value = -99) 
+            print(f"-- The used data includes a total track length of {tot_data_length} cm.")
+            print(f"-- The maximum batch track length is {max_batch_len} cm.")
+            print(f"-- There are {len(batches)} different batches in total.")
 
-        print("training set [ev, trk]: ", fit_index)
+        self.tracks = torch.nn.utils.rnn.pad_sequence(fit_tracks, batch_first=True, padding_value = -99) 
 
     def __len__(self):
         return len(self.tracks)

--- a/optimize/dataio.py
+++ b/optimize/dataio.py
@@ -13,7 +13,7 @@ def structured_from_torch(tracks_torch, dtype):
     return rfn.unstructured_to_structured(tracks_torch.cpu().numpy(), dtype=dtype)
 
 class TracksDataset(Dataset):
-    def __init__(self, filename, ntrack, swap_xz=True, seed=3, random_ntrack=False, track_zlen_sel=30., 
+    def __init__(self, filename, ntrack, swap_xz=True, seed=3, random_ntrack=False, track_zlen_sel=0., 
                  track_z_bound=28., max_batch_len=None):
 
         with h5py.File(filename, 'r') as f:

--- a/optimize/example_run.py
+++ b/optimize/example_run.py
@@ -23,10 +23,16 @@ def make_param_list(config):
 
 def main(config):
     dataset = TracksDataset(filename=config.input_file, ntrack=config.data_sz, seed=config.data_seed, random_ntrack=config.random_ntrack, 
-                            track_zlen_sel=config.track_zlen_sel, track_z_bound=config.track_z_bound)
+                            track_zlen_sel=config.track_zlen_sel, track_z_bound=config.track_z_bound, max_batch_len=config.max_batch_len)
+
+    batch_sz = config.batch_sz
+    if config.max_batch_len is not None and batch_sz != 1:
+        print("Need batch size == 1 for splitting in dx chunks. Setting now...")
+        batch_sz = 1
+
     tracks_dataloader = DataLoader(dataset,
                                   shuffle=config.data_shuffle, 
-                                  batch_size=config.batch_sz,
+                                  batch_size=batch_sz,
                                   pin_memory=True, num_workers=config.num_workers)
 
     # For readout noise: no_noise overrides if explicitly set to True. Otherwise, turn on noise
@@ -113,6 +119,8 @@ if __name__ == '__main__':
                         help="Number of iterations to run. Overrides epochs.")
     parser.add_argument("--loss_fn", dest="loss_fn", default=None,
                         help="Loss function to use. Named options are SDTW and space_match.")
+    parser.add_argument("--max_batch_len", dest="max_batch_len", default=None,
+                        help="Max dx per batch. If passed, will add tracks to batch until overflow, splitting where needed")
     try:
         args = parser.parse_args()
         retval, status_message = main(args)

--- a/optimize/example_run.py
+++ b/optimize/example_run.py
@@ -119,8 +119,8 @@ if __name__ == '__main__':
                         help="Number of iterations to run. Overrides epochs.")
     parser.add_argument("--loss_fn", dest="loss_fn", default=None,
                         help="Loss function to use. Named options are SDTW and space_match.")
-    parser.add_argument("--max_batch_len", dest="max_batch_len", default=None,
-                        help="Max dx per batch. If passed, will add tracks to batch until overflow, splitting where needed")
+    parser.add_argument("--max_batch_len", dest="max_batch_len", default=None, type=float,
+                        help="Max dx [cm] per batch. If passed, will add tracks to batch until overflow, splitting where needed")
     try:
         args = parser.parse_args()
         retval, status_message = main(args)

--- a/optimize/example_run.py
+++ b/optimize/example_run.py
@@ -97,7 +97,7 @@ if __name__ == '__main__':
                         help="Save frequency of the result")
     parser.add_argument("--random_ntrack", dest="random_ntrack", default=False, action="store_true",
                         help="Flag of whether sampling the tracks randomly or sequentially")
-    parser.add_argument("--track_zlen_sel", dest="track_zlen_sel", default=30., type=float,
+    parser.add_argument("--track_zlen_sel", dest="track_zlen_sel", default=2., type=float,
                         help="Track selection requirement on the z expansion (drift axis)")
     parser.add_argument("--track_z_bound", dest="track_z_bound", default=28., type=float,
                         help="Set z bound to keep healthy set of tracks")

--- a/optimize/fit_params.py
+++ b/optimize/fit_params.py
@@ -187,7 +187,7 @@ class ParamFitter:
 
             
     def fit(self, dataloader, epochs=300, iterations=None, shuffle=False, 
-            save_freq=5, print_freq=1, save_freq_iter=10, print_freq_iter=1):
+            save_freq=10, print_freq=1):
         # If explicit number of iterations, scale epochs accordingly
         if iterations is not None:
             epochs = iterations // len(dataloader) + 1
@@ -301,16 +301,16 @@ class ParamFitter:
                                                                                             param, scheme=self.norm_scheme, undo_norm=True))
 
                             if iterations is not None:
-                                if total_iter % print_freq_iter == 0:
+                                if total_iter % print_freq == 0:
                                     for param in self.relevant_params_list:
                                         print(param, getattr(self.sim_physics,param).item())
                                     
-                                if total_iter % save_freq_iter == 0:
+                                if total_iter % save_freq == 0:
                                     with open(f'history_{param}_iter{total_iter}_{self.out_label}.pkl', "wb") as f_history:
                                         pickle.dump(self.training_history, f_history)
 
-                                    if os.path.exists(f'history_{param}_iter{total_iter-save_freq_iter}_{self.out_label}.pkl'):
-                                        os.remove(f'history_{param}_iter{total_iter-save_freq_iter}_{self.out_label}.pkl') 
+                                    if os.path.exists(f'history_{param}_iter{total_iter-save_freq}_{self.out_label}.pkl'):
+                                        os.remove(f'history_{param}_iter{total_iter-save_freq}_{self.out_label}.pkl') 
 
                     total_iter += 1
                     pbar.update(1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,7 +16,7 @@ def calc_forward(with_grad=False, param_list=[], shift=0.05, device='cpu'):
     pixel_layouts = "larndsim/pixel_layouts/multi_tile_layout-2.2.16.yaml"
     input_file =  "tests/data/test_inputs.h5"
 
-    dataset = TracksDataset(filename=input_file, ntrack=1, track_zlen_sel=0, track_z_bound=32)
+    dataset = TracksDataset(filename=input_file, ntrack=1, track_len_sel=0, track_z_bound=32)
     selected_tracks_torch = dataset[0][0:1]
     track_fields = dataset.get_track_fields()
 


### PR DESCRIPTION
Added a flag/some logic to set a max dx per batch and grab tracks appropriately. This fills up batches track-wise, ensuring that we never go over the max dx value, splitting tracks into segments accordingly. One user note is that this requires a `batch_sz == 1` in the DataLoader, since we're already grouping by dx chunks (which take the place of the "tracks" level grouping as a collection of segments), and I explicitly enforce this.

Haven't tested, will do tomorrow, so still draft