### PR TITLE
Correct output nans

### DIFF
--- a/larndsim/detsim_ep.py
+++ b/larndsim/detsim_ep.py
@@ -15,7 +15,7 @@ from .utils import diff_arange
 import logging
 
 logging.basicConfig()
-logger = logging.getLogger('detsim')
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 logger.info("DETSIM MODULE PARAMETERS")
 
@@ -179,13 +179,14 @@ class detsim(consts):
                    (-self.erf_hack(b/padded_sqrt_a_2) +
                     self.erf_hack((b + 2*(a*Deltar)[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis])/
                                   padded_sqrt_a_2)) / padded_sqrt_a_2
-
-       # expo = ep.exp(b*b/(4*a[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]) - delta + ep.log(factor[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]) + ep.log(integral))
-        #expo = ep.where(expo.isnan(), 0, expo)
+        
+        # expo = ep.exp(b*b/(4*a[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]) - delta + ep.log(factor[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]) + ep.log(integral))
+        # expo = ep.where(expo.isnan(), 0, expo)
         #Avoid logs by bringing down - should be equiv?
         expo = ep.exp(b*b/(4*a[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]) - delta) * \
                factor[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]*integral
-
+        expo = ep.where(expo.isnan(), 0, expo)
+        
         #TODO: Figure out a way to do the sum over the sampling cube here.
         # Ask about the x_dist, y_dist > pixel_pitch/2 conditions in the original simulation
         return expo

--- a/larndsim/detsim_ep.py
+++ b/larndsim/detsim_ep.py
@@ -183,9 +183,12 @@ class detsim(consts):
         # expo = ep.exp(b*b/(4*a[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]) - delta + ep.log(factor[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]) + ep.log(integral))
         # expo = ep.where(expo.isnan(), 0, expo)
         #Avoid logs by bringing down - should be equiv?
-        expo = ep.exp(b*b/(4*a[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]) - delta) * \
-               factor[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]*integral
+        expo_factor = ep.where(ep.logical_and(factor != 0, integral != 0), b*b/(4*a[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]) - delta, 0)
+        expo = ep.exp(expo_factor)*factor[:, ep.newaxis, ep.newaxis, ep.newaxis, ep.newaxis]*integral
+        # logger.debug(f"Got {np.count_nonzero(np.isnan(expo.raw.detach().cpu().numpy()))} NaNs in expo")
         expo = ep.where(expo.isnan(), 0, expo)
+
+        
         
         #TODO: Figure out a way to do the sum over the sampling cube here.
         # Ask about the x_dist, y_dist > pixel_pitch/2 conditions in the original simulation

--- a/larndsim/drifting_ep.py
+++ b/larndsim/drifting_ep.py
@@ -11,7 +11,7 @@ from .consts_ep import consts
 import logging
 
 logging.basicConfig()
-logger = logging.getLogger("drifting")
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 logger.info("DRIFTING MODULE PARAMETERS")
 

--- a/larndsim/pixels_from_track_ep.py
+++ b/larndsim/pixels_from_track_ep.py
@@ -13,7 +13,7 @@ from .consts_ep import consts
 import logging
 
 logging.basicConfig()
-logger = logging.getLogger('pixels_from_track')
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 logger.info("PIXEL_FROM_TRACK MODULE PARAMETERS")
 

--- a/larndsim/quenching_ep.py
+++ b/larndsim/quenching_ep.py
@@ -10,7 +10,7 @@ from .consts_ep import consts
 import logging
 
 logging.basicConfig()
-logger = logging.getLogger('quenching')
+logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 logger.info("QUENCHING MODULE PARAMETERS")
 

--- a/larndsim/sim_with_grad.py
+++ b/larndsim/sim_with_grad.py
@@ -41,4 +41,4 @@ class sim_with_grad(quench, drift, pixels_from_track, detsim, fee):
 
         nb_bytes_per_elt = 128
 
-        return nb_elts*nb_bytes_per_elt/1024/1024 #Returns in Mio
+        return nb_elts*nb_bytes_per_elt/1024/1024 + 200 #Returns in Mio with a safety margin

--- a/larndsim/sim_with_grad.py
+++ b/larndsim/sim_with_grad.py
@@ -25,8 +25,10 @@ class sim_with_grad(quench, drift, pixels_from_track, detsim, fee):
         x_diff = ep.abs(tracks_ep[:, fields.index("x_end")] - tracks_ep[:, fields.index("x_start")])
         y_diff = ep.abs(tracks_ep[:, fields.index("y_end")] - tracks_ep[:, fields.index("y_start")])
 
+        cond = x_diff.square() + y_diff.square() > 0
 
-        cotan2 = (z_diff.square())/(x_diff.square() + y_diff.square())
+        cotan2 = ep.where(cond, z_diff.square()/(x_diff.square() + y_diff.square()), 0)
+
         pixel_diagonal = sqrt(self.pixel_pitch ** 2 + self.pixel_pitch ** 2)
         sigma_T = sqrt(((self.drift_length + 0.5)/self.vdrift)*2*self.tran_diff)
         sigma_L = sqrt(((self.drift_length + 0.5)/self.vdrift)*2*self.long_diff)

--- a/optimize/dataio.py
+++ b/optimize/dataio.py
@@ -4,6 +4,10 @@ import torch
 from torch.utils.data import Dataset
 from numpy.lib import recfunctions as rfn
 import random
+import logging
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 def torch_from_structured(tracks):
     tracks_np = rfn.structured_to_unstructured(tracks, copy=True, dtype=np.float32)
@@ -78,7 +82,7 @@ class TracksDataset(Dataset):
                 fit_tracks.append(all_tracks[i_rand])
 
         if print_input:
-            print("training set [ev, trk]: ", fit_index)
+            logger.info(f"training set [ev, trk]: {fit_index}")
       
         if max_batch_len is not None:
             batches = []
@@ -103,10 +107,10 @@ class TracksDataset(Dataset):
                             batches.append(torch.stack(batch_here))
                             tot_data_length += tot_length - segment[self.track_fields.index("dx")]
                             if print_input:
-                                print("~ [batch ID]: ", len(batches))
-                                print("  batch length: ", tot_length - segment[self.track_fields.index("dx")])
-                                print("  event IDs: ", ev_here)
-                                print("  track IDs: ", trk_here)
+                                logger.info(f"~ [batch ID]: {len(batches)}")
+                                logger.info(f"  batch length: {tot_length - segment[self.track_fields.index('dx')]}")
+                                logger.info(f"  event IDs: {ev_here}")
+                                logger.info(f"  track IDs: {trk_here}")
                         batch_here = []
                         ev_here = []
                         trk_here = []
@@ -126,9 +130,9 @@ class TracksDataset(Dataset):
             
             fit_tracks = batches
 
-            print(f"-- The used data includes a total track length of {tot_data_length} cm.")
-            print(f"-- The maximum batch track length is {max_batch_len} cm.")
-            print(f"-- There are {len(batches)} different batches in total.")
+            logger.info(f"-- The used data includes a total track length of {tot_data_length} cm.")
+            logger.info(f"-- The maximum batch track length is {max_batch_len} cm.")
+            logger.info(f"-- There are {len(batches)} different batches in total.")
 
         self.tracks = torch.nn.utils.rnn.pad_sequence(fit_tracks, batch_first=True, padding_value = -99) 
 

--- a/optimize/example_run.py
+++ b/optimize/example_run.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 
+import logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
 import argparse
 import yaml
 import sys, os
@@ -8,15 +11,19 @@ from torch.utils.data import DataLoader
 import json
 import numpy as np
 
+
 from .fit_params import ParamFitter
 from .dataio import TracksDataset
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 def make_param_list(config):
     if len(config.param_list) == 1 and os.path.splitext(config.param_list[0])[1] == ".yaml":
         with open(config.param_list[0], 'r') as config_file:
             config_dict = yaml.load(config_file, Loader=yaml.FullLoader)
         for key in config_dict.keys():
-            print(f"Setting lr {config_dict[key]} for {key}")
+            logger.info(f"Setting lr {config_dict[key]} for {key}")
         param_list = config_dict
     else:
         param_list = config.param_list
@@ -26,7 +33,7 @@ def make_param_list(config):
 def main(config):
 
     if config.print_input:
-        print("fit label: ", config.out_label)
+        logger.info(f"fit label: {config.out_label}")
 
     iterations = config.iterations
     max_nbatch = config.max_nbatch
@@ -40,7 +47,7 @@ def main(config):
 
     batch_sz = config.batch_sz
     if config.max_batch_len is not None and batch_sz != 1:
-        print("Need batch size == 1 for splitting in dx chunks. Setting now...")
+        logger.warning("Need batch size == 1 for splitting in dx chunks. Setting now...")
         batch_sz = 1
 
     tracks_dataloader = DataLoader(dataset,
@@ -173,5 +180,5 @@ if __name__ == '__main__':
         retval = 1
         status_message = 'Error: Fitting failed.'
 
-    print(status_message)
+    logger.info(status_message)
     exit(retval)

--- a/optimize/fit_params.py
+++ b/optimize/fit_params.py
@@ -7,9 +7,13 @@ import numpy as np
 from .utils import get_id_map, all_sim, embed_adc_list, calc_loss, calc_soft_dtw_loss
 from .ranges import ranges
 from larndsim.sim_with_grad import sim_with_grad
+import logging
 import torch
 
 from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 def normalize_param(param_val, param_name, scheme="divide", undo_norm=False):
     if scheme == "divide":
@@ -61,7 +65,7 @@ class ParamFitter:
         self.norm_scheme = norm_scheme
         self.max_clip_norm_val = max_clip_norm_val
         if self.max_clip_norm_val is not None:
-            print(f"Will clip gradient norm at {self.max_clip_norm_val}")
+            logger.info(f"Will clip gradient norm at {self.max_clip_norm_val}")
 
         self.fit_diffs = fit_diffs
         # If you have access to a GPU, sim works trivially/is much faster
@@ -114,7 +118,7 @@ class ParamFitter:
                 setattr(self.sim_iter, param, normalize_param(history[param][-1], param, scheme=self.norm_scheme))
             else:
                 if vary_init:
-                    print("Running with random initial guess")
+                    logger.info("Running with random initial guess")
                     init_val = np.random.uniform(low=ranges[param]['down'], 
                                                   high=ranges[param]['up'])
                     setattr(self.sim_iter, param, normalize_param(init_val, param, scheme=self.norm_scheme))
@@ -162,7 +166,7 @@ class ParamFitter:
         if lr_scheduler is not None and lr_kw is not None:
             lr_scheduler_fn = getattr(torch.optim.lr_scheduler, lr_scheduler)
             self.lr_scheduler = lr_scheduler_fn(self.optimizer, **lr_kw)
-            print(f"Using learning rate scheduler {lr_scheduler}")
+            logger.info(f"Using learning rate scheduler {lr_scheduler}")
         else:
             self.lr_scheduler = None
 
@@ -174,7 +178,7 @@ class ParamFitter:
                                 'return_components' : False,
                                 'no_adc' : self.no_adc 
                               }
-            print("Using space match loss")
+            logger.info("Using space match loss")
         elif loss_fn == "SDTW":
             self.loss_fn = calc_soft_dtw_loss
 
@@ -187,13 +191,13 @@ class ParamFitter:
                                 'gamma' : 1
                               }
             if t_only:
-                print("Using Soft DTW loss on t only")
+                logger.info("Using Soft DTW loss on t only")
             else:
-                print("Using Soft DTW loss on ADC only")
+                logger.info("Using Soft DTW loss on ADC only")
         else:
             self.loss_fn = loss_fn
             self.loss_fn_kw = {}
-            print("Using custom loss function")
+            logger.info("Using custom loss function")
 
         if is_continue:
             self.training_history = history
@@ -219,18 +223,18 @@ class ParamFitter:
 
     def make_target_sim(self, seed=2, fixed_range=None):
         np.random.seed(seed)
-        print("Constructing target param simulation")
+        logger.info("Constructing target param simulation")
 
         if self.target_val_dict is not None:
             if set(self.relevant_params_list + self.shift_no_fit) != set(self.target_val_dict.keys()):
-                print(set(self.relevant_params_list + self.shift_no_fit))
-                print(set(self.target_val_dict.keys()))
+                logger.debug(set(self.relevant_params_list + self.shift_no_fit))
+                logger.debug(set(self.target_val_dict.keys()))
                 raise ValueError("Must specify all parameters if explicitly setting target")
 
-            print("Explicitly setting targets:")
+            logger.info("Explicitly setting targets:")
             for param in self.target_val_dict.keys():
                 param_val = self.target_val_dict[param]
-                print(f'{param}, target: {param_val}, init {getattr(self.sim_physics, param)}')    
+                logger.info(f'{param}, target: {param_val}, init {getattr(self.sim_physics, param)}')    
                 setattr(self.sim_target, param, param_val)
         else:
             for param in self.relevant_params_list + self.shift_no_fit:
@@ -241,7 +245,7 @@ class ParamFitter:
                     param_val = np.random.uniform(low=ranges[param]['down'], 
                                                 high=ranges[param]['up'])
 
-                print(f'{param}, target: {param_val}, init {getattr(self.sim_physics, param)}')    
+                logger.info(f'{param}, target: {param_val}, init {getattr(self.sim_physics, param)}')    
                 setattr(self.sim_target, param, param_val)
 
 
@@ -250,7 +254,7 @@ class ParamFitter:
             estimated_memory = sim.estimate_peak_memory(tracks, self.track_fields)
             chunk_size = int(self.batch_memory // estimated_memory)
             chunk_size = max(1, chunk_size) #Min value should be 1
-            print(f"Initial maximum memory of {estimated_memory/1024:.2f}Gio. Setting pixel_chunk_size to {chunk_size} and expect a maximum memory of {chunk_size*estimated_memory/1024:.2f}Gio")
+            logger.info(f"Initial maximum memory of {estimated_memory/1024:.2f}Gio. Setting pixel_chunk_size to {chunk_size} and expect a maximum memory of {chunk_size*estimated_memory/1024:.2f}Gio")
             sim.update_chunk_sizes(1, chunk_size)
 
     
@@ -332,7 +336,7 @@ class ParamFitter:
                         # Undo normalization (sim -> sim_physics)
                         for param in self.relevant_params_list:
                             setattr(self.sim_physics, param, normalize_param(getattr(self.sim_iter, param), param, scheme=self.norm_scheme, undo_norm=True))
-                            print(param, getattr(self.sim_physics, param))
+                            logger.debug(f"{param} {getattr(self.sim_physics, param)}")
 
                         # Simulate and get output
                         #Update chunk sizes based on memory calculations
@@ -379,10 +383,13 @@ class ParamFitter:
                                 self.training_history[param+"_iter"].append(normalize_param(getattr(self.sim_iter, param).item(), 
                                                                                             param, scheme=self.norm_scheme, undo_norm=True))
 
+                        else:
+                            logger.warning(f"Got {nan_check} gradients with a NaN value!")
+
                     if iterations is not None:
                         if total_iter % print_freq == 0:
                             for param in self.relevant_params_list:
-                                print(param, getattr(self.sim_physics,param).item())
+                                logger.info(f"{param} {getattr(self.sim_physics,param).item()}")
                             
                         if total_iter % save_freq == 0:
                             with open(f'fit_result/history_{param}_iter{total_iter}_{self.out_label}.pkl', "wb") as f_history:
@@ -404,7 +411,7 @@ class ParamFitter:
                 # Print out params at each epoch
                 if epoch % print_freq == 0 and iterations is None:
                     for param in self.relevant_params_list:
-                        print(param, getattr(self.sim_physics,param).item())
+                        logger.info(f"{param} {getattr(self.sim_physics,param).item()}")
 
                 # Keep track of training history
                 for param in self.relevant_params_list:
@@ -460,7 +467,7 @@ class ParamFitter:
 
                 # set up target per batch
                 for ev in unique_eventIDs:
-                    print("batch: " + str(i) + '; ev:' + str(int(ev)))
+                    logger.info("batch: " + str(i) + '; ev:' + str(int(ev)))
                     selected_tracks_torch = selected_tracks_bt_torch[selected_tracks_bt_torch[:, self.track_fields.index("eventID")] == ev]
                     selected_tracks_torch = selected_tracks_torch.to(self.device)
 
@@ -495,7 +502,7 @@ class ParamFitter:
                         for param in self.relevant_params_list:
                             setattr(self.sim_physics, param, getattr(self.sim_iter, param)*ranges[param]['nom'])
                             if run_no % print_freq == 0:
-                                print(param, getattr(self.sim_physics, param))
+                                logger.info(f"{param}, {getattr(self.sim_physics, param)}")
 
                         # Simulate and get output
                         output, pix_out, ticks_list_out = all_sim(self.sim_physics, selected_tracks_torch, self.track_fields,
@@ -511,6 +518,8 @@ class ParamFitter:
                         # To be investigated -- sometimes we get nans. Avoid doing a step if so
                         if not loss.isnan():
                             loss_ev_per_val.append(loss)
+                        else:
+                            logger.warning("Got NaN as loss!")
 
                     # Average out the loss in different events per batch
                     if len(loss_ev_per_val) > 0:


### PR DESCRIPTION
Adding a NaN filtering on the output of the rho function. These NaNs are an artifact of an `exp(large_number)*0` computation and should actually be 0. It was checked that this doesn't impact the gradient calculation.
Also tried to add a safety margin in the batch memory estimation to try to avoid memory issues that still popped out.
Replaced the `print` statements with the logging interface for better output readability (and possibly better control over it later with some verbosity option).
