### PR TITLE
Added ability to preload data + make_plots.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Most of the physics code is in `larndsim/`, while the optimization code is in `o
 SDF (so that you can use the corresponding resources and file paths). The heart of the user interface is the file `optimize/example_run.py`, 
 which makes use of the `ParamFitter` class defined in `optimize/fit_params.py`, as well as the data handling of `optimize/dataio.py`. 
 
-In this version, data can be **"preloaded"** by running `sbatch optimize/scripts/`
+In this version, data can be **"preloaded"** by running `sbatch optimize/scripts/make_dataio_cut.sh` from the top-level `larnd-sim` directory, which runs `make_dataio_cut.py`.
 
 An image containing all required packages is located at:
 `/sdf/group/neutrino/images/larndsim_latest.sif`
@@ -102,10 +102,11 @@ to make something like this plot:
 
 <img alt="example fit" src="figures/plot_Ab_Ab_SDTW_lr1e-2_5trk_test.png" height="500">
 
-Which was made with a very very simple plotting script
+Which was made with a not-so very simple plotting script
 ``` bash
 singularity exec --bind /fs /sdf/group/neutrino/images/latest.py python3 make_plots.py --params Ab --label Ab_SDTW_lr1e-2_5trk_test --seeds 1 2 3 4 5 --ext png
 ```
+This plotting scripts has been upgraded considerably to plot many other things, which is discussed in more detail below.
 
 You might notice this looks quite wiggly -- this is often a sign of the learning rate being too high.  This can be tuned with the `--lr` flag -- 
 try it yourself!
@@ -114,7 +115,7 @@ The parameters of interest for fitting are (currently), in rough priority order:
 - Ab
 - kb
 - tran_diff
-- vdrift
+- vdrift <-> Field  (_they are linked_)
 - lifetime
 - eField
 - long_diff
@@ -126,6 +127,7 @@ The example we had you run does a fit for a single parameter (Ab) on a limited s
 either:
 - A space separated list of parameters (one learning rate used for all)
 - A `.yaml` file defining the list of parameters and their associated learning rates, e.g.,
+one is already stored in `optimize/scripts/param_list.yaml`
 
 ``` yaml
 Ab: 1e-2
@@ -134,3 +136,15 @@ kb: 1e-1
 will run a simultaneous (2D) fit in `Ab` and `kb` with learning rates 1e-2 and 1e-1 respectively.
 
 There are several other configuration flags, please see the included help text for more information on those. 
+
+## Making plots using `make_plots.py`
+
+Make_plots.py has the capability to plot dEdx counts from input edep-sim .h5 files, simulation loss values from .pkl run files, parameter fit iterations from .pkl's, and parameter convergences from .pkl's.
+Make sure you are in the directory where your .pkl files are, which by default are stored in `fit_result/`. 
+- choose which runs to plot using `--label my_run_label` to search for the label in the .pkl file name.
+- You can specify which seeds to plot using `--seeds 1 3 5 8` for any number of relevant seeds. 
+Use --plot followed by any of the following keywords to run various plots
+- all, param: plot parameter iterations
+- conv: plot parameter convergences
+- loss [UNIF_LEN] [avg]: plot simulation loss smoothed with a moving average UNIF_LEN large, and use an updating average with 'avg'
+- dedx [NUM_BINS]: plot a histogram of dEdx counts in various input data. Customize in `make_plots.py` line 471

--- a/README.md
+++ b/README.md
@@ -143,7 +143,8 @@ Make_plots.py has the capability to plot dEdx counts from input edep-sim .h5 fil
 Make sure you are in the directory where your .pkl files are, which by default are stored in `fit_result/`. 
 - choose which runs to plot using `--label my_run_label` to search for the label in the .pkl file name.
 - You can specify which seeds to plot using `--seeds 1 3 5 8` for any number of relevant seeds. 
-Use --plot followed by any of the following keywords to run various plots
+
+Use `--plot` followed by any of the following keywords to run various plots
 - all, param: plot parameter iterations
 - conv: plot parameter convergences
 - loss [UNIF_LEN] [avg]: plot simulation loss smoothed with a moving average UNIF_LEN large, and use an updating average with 'avg'

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Most of the physics code is in `larndsim/`, while the optimization code is in `o
 SDF (so that you can use the corresponding resources and file paths). The heart of the user interface is the file `optimize/example_run.py`, 
 which makes use of the `ParamFitter` class defined in `optimize/fit_params.py`, as well as the data handling of `optimize/dataio.py`. 
 
+In this version, data can be **"preloaded"** by running `sbatch optimize/scripts/`
+
 An image containing all required packages is located at:
 `/sdf/group/neutrino/images/larndsim_latest.sif`
 
@@ -102,7 +104,7 @@ to make something like this plot:
 
 Which was made with a very very simple plotting script
 ``` bash
-python make_plots.py --params Ab --label Ab_SDTW_lr1e-2_5trk_test --seeds 1 2 3 4 5 --ext png
+singularity exec --bind /fs /sdf/group/neutrino/images/latest.py python3 make_plots.py --params Ab --label Ab_SDTW_lr1e-2_5trk_test --seeds 1 2 3 4 5 --ext png
 ```
 
 You might notice this looks quite wiggly -- this is often a sign of the learning rate being too high.  This can be tuned with the `--lr` flag -- 

--- a/make_dataio_cut.py
+++ b/make_dataio_cut.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+
+import h5py
+import torch
+import numpy as np
+from numpy.lib import recfunctions as rfn
+import os, sys
+from tqdm import tqdm
+from glob import glob
+import argparse
+
+
+# used in dataio
+def torch_from_structured(tracks):
+    tracks_np = rfn.structured_to_unstructured(tracks, copy=True, dtype=np.float32)
+    #return torch.from_numpy(tracks_np).float() # changed in dataio, cant store torch arrays
+    return np.array(tracks_np)
+
+def dataio_cut(filename, out_name, dEdx_threshold, is_max, 
+               swap_xz, track_len_sel, max_abs_costheta_sel, min_abs_segz_sel, track_z_bound):
+    
+    print(f"Loading tracks from {filename}...")
+    with h5py.File(filename, 'r') as f:
+        tracks = np.array(f['segments'])
+    num_tot_tracks = len(tracks)
+    print(f"There are {num_tot_tracks} tracks")
+    
+    if swap_xz:
+        print("Swapping x & z...")
+        x_start = np.copy(tracks['x_start'] )
+        x_end = np.copy(tracks['x_end'])
+        x = np.copy(tracks['x'])
+
+        tracks['x_start'] = np.copy(tracks['z_start'])
+        tracks['x_end'] = np.copy(tracks['z_end'])
+        tracks['x'] = np.copy(tracks['z'])
+
+        tracks['z_start'] = x_start
+        tracks['z_end'] = x_end
+        tracks['z'] = x
+
+    # flat index for all reasonable track [eventID, trackID] 
+    add = "<" if is_max else ">"
+    if dEdx_threshold: # is not None
+        print(f"Cutting tracks w/ dEdx {add} {dEdx_threshold}...")
+    else:
+        print(f"Cutting tracks...")
+    # make datasets to store in h5
+    index = []
+    all_tracks = np.empty(shape=(1,len(tracks.dtype.names)), dtype='float64')
+    cut_tracks = np.empty(shape=(1), dtype=tracks.dtype) ##[track1, track2]
+    events = np.unique(tracks['eventID'])
+    num_tracks_added = 0
+    with tqdm(total = len(events)) as pbar:
+        for count, ev in enumerate(events):
+            track_set = np.unique(tracks[tracks['eventID'] == ev]['trackID'])
+            for trk in track_set:
+                trk_msk = (tracks['eventID'] == ev) & (tracks['trackID'] == trk)
+                track = tracks[trk_msk]
+                xd = track['x_start'][0] - track['x_end'][-1]
+                yd = track['y_start'][0] - track['y_end'][-1]
+                zd = track['z_start'][0] - track['z_end'][-1]
+                z_dir = [0,0,1]
+                trk_dir = [xd, yd, zd]
+                # selection criteria: track length, track direction not in z, max z comp not too high-->
+                #                     now select only segments in track that arent nuclei and above min z
+                if np.sum(track['dx']) > track_len_sel:
+                    cos_theta = abs(np.dot(trk_dir, z_dir))/ np.linalg.norm(trk_dir)
+                    if max(abs(track['z'])) < track_z_bound and abs(cos_theta) < max_abs_costheta_sel:
+                        msk = np.logical_and(abs(track['z']) > min_abs_segz_sel, track['pdgId'] < 1e6)
+                        num_new_tracks = len(track[msk])
+                        if num_new_tracks > 0:  # continue if masked tracks are nonzero
+                            # ENERGY threshold CUT
+                            if dEdx_threshold != None:
+                                mean_energy = np.mean(track[msk]['dEdx'])
+                                if (mean_energy > dEdx_threshold and not is_max) or (mean_energy < dEdx_threshold and is_max):
+                                    num_tracks_added += num_new_tracks
+                                    index.append([ev, trk])
+                                    cut_tracks = np.append(cut_tracks, track[msk])
+                                    all_tracks = np.append(all_tracks, torch_from_structured(track[msk]), 0)
+                            else:
+                                num_tracks_added += num_new_tracks
+                                index.append([ev, trk])
+                                cut_tracks = np.append(cut_tracks, track[msk])
+                                all_tracks = np.append(all_tracks, torch_from_structured(track[msk]), 0)
+            print(f"B-) Number of cut tracks: {num_tracks_added}")
+            pbar.update(1)
+    # now generate new h5py file with said datasets
+    if out_name == None:
+        out_name = filename.split('/')[-1].split('.h5')[0]+(str(dEdx_threshold) if dEdx_threshold > 0 else '')
+    f = h5py.File(f'{out_name}.h5','w')
+    f.create_dataset('segments', data=cut_tracks)   # all cut segments
+    f.create_dataset('index', data=index)           # indices of said segments
+    f.create_dataset('all_tracks', data=all_tracks) # torch formatted data
+    f.close()
+    print(f"Saved cut data ({num_tracks_added}/{num_tot_tracks}) to {out_name}.h5 in {os.getcwd()}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(dest="filename", help="Filename to make data cut from")
+    parser.add_argument("--out", dest="out_name", default = None,
+                        help="Name of output file for making dataio")
+    parser.add_argument("--threshold", dest="threshold", default = None, type=float,
+                        help="Threshold for minimum/maximum avg dEdx value to cut from")
+    parser.add_argument("--max", dest="is_max", default = False, action="store_true",
+                        help="default threshold is the min avg dedx, change to the max avg dedx")     
+    parser.add_argument("--swap_xz", dest="swap_xz", default=True, action="store_false",
+                        help="Swap x and z axes in data")             
+    parser.add_argument("--track_len_sel", dest="track_len_sel", default=2., type=float,
+                        help="Track selection requirement on track length.")
+    parser.add_argument("--max_abs_costheta_sel", dest="max_abs_costheta_sel", default=0.966, type=float,
+                        help="Theta is the angle of track wrt to the z axis. Remove tracks which are very colinear with z.")
+    parser.add_argument("--min_abs_segz_sel", dest="min_abs_segz_sel", default=15., type=float,
+                        help="Remove track segments that are close to the cathode.")
+    parser.add_argument("--track_z_bound", dest="track_z_bound", default=28., type=float,
+                        help="Set z bound to keep healthy set of tracks")
+    args = parser.parse_args()
+    dataio_cut(args.filename, args.out_name, args.threshold, args.is_max, args.swap_xz,
+               args.track_len_sel, args.max_abs_costheta_sel, args.min_abs_segz_sel, args.track_z_bound)
+    

--- a/make_plots.py
+++ b/make_plots.py
@@ -2,48 +2,660 @@
 
 import argparse
 import pickle
+import h5py
+import matplotlib as mpl
 import matplotlib.pyplot as plt
+from cycler import cycler
+
 import numpy as np
 from glob import glob
+import os, sys
+from optimize.ranges import ranges
+import scipy
+from scipy.ndimage import uniform_filter1d
 
-labels = {'Ab' : 'Ab',
-          'kb' : 'kb [g/cm$^2$/MeV]',
-          'lifetime' : 'lifetime [$\mu s$]' ,
-          'long_diff' : 'long_diff [$cm^2/\mu s$]',
-          'tran_diff' : 'tran_diff [$cm^2/\mu s$]',
-          'vdrift' : 'vdrift [$cm/\mu s$]',
-          'eField' : 'eField [kV/cm]'}
 
-def main(config):
-    for param in config.params:
-        for count, seed in enumerate(config.seeds):
-            try:
-                fname = glob(f"history*_seed{seed}_{config.label}.pkl")[0]
-            except:
-                continue
+# ----------------- Constants ----------------------- #
+# set matplotlib color rotation to have more options, hexcolor website: https://www.colorhexa.com/
+#            greyblue   orange    green    midred   grey prpl   BROWN     PINK     drkGREY   
+hexcolors = ['1f77b4', 'ff7f0e', '2ca02c', 'd62728', '9467bd', '8c564b', 'ffc0cb', '696969', 
+             '00008b', 'ffaa88', '66ffaa', '8b0000', '17becf', '800080', 'bbbbbb',  '87ceeb', 'bcbd22', 'eeee00', '000000']
+#             drk blue | peach  |  lime  |  drkred  |  cyan |   purple  | ltgrey | SKY BLUE | gry yellow | yellow | black
+mpl.rcParams['axes.prop_cycle'] = cycler('color', [mpl.colors.to_rgba('#' + c) for c in hexcolors])
 
-            history = pickle.load(open(fname, "rb"))
+# used when making dEdx histograms
+h5_dict = '/sdf/home/b/bkroul/l-sim/h5/'
+files_dict = {'muon':     h5_dict + 'old_data_cut.h5',
+              'proton':   h5_dict +'first_data_cut_high_dEdx.h5',
+              'dEdx > 5': h5_dict + 'proton_min-dEdx5.h5',
+              'dEdx < 2': h5_dict + 'proton_max-dEdx2.h5',
+              'proton_no_nuclei': h5_dict + 'proton_dEdx_no_nuclei.h5',
+              'muon_raw': '/fs/ddn/sdf/group/neutrino/cyifan/muon-sim/fake_data_S1/edepsim-output.h5',
+              'proton_raw': '/fs/ddn/sdf/group/neutrino/cyifan/muon-sim/larndsim_output/f1_1000_p_high_KE/edepsim-output.h5'
+             }
 
-            plt.plot(np.asarray(history[f"{param}_iter"]), c=f'C{count}')
-            plt.plot([0, len(history[f"{param}_iter"])], [history[f'{param}_target']]*2, c=f'C{count}', ls='dashed')
+# labels for y-axis when plotting parameter iterations
+labels = {'Ab' : "$A_{B}$",
+          'kb' : "$k_{B}$ [g/cm$^2$/MeV]",
+          'lifetime' : "$\\tau$ [$\mu s$]",
+          'long_diff' : "$D_{L}$ [$cm^2/\mu s$]",
+          'tran_diff' : "$D_{T}$ [$cm^2/\mu s$]",
+          #'vdrift' : 'vdrift [$cm/\mu s$]', # we use link_vdrift_efield now
+          'eField' : "$\\epsilon$ [kV/cm]"}
 
-        plt.ylabel(labels[param])
-        plt.xlabel('Training Iteration')
-        plt.tight_layout()
-        plt.savefig(f'plot_{param}_{config.label}.{config.ext}', dpi=300)
-        print(f"Saving plot to plot_{param}_{config.label}.{config.ext}")
+# dictionary of all particles found in input data so far
+pdgIds = {1: "d", 2: "u", 3: "s", 4: "c", 5: "b", 6:"t", 7:"b'", 8:"t'", # quarks
+          -11:"e+", 11: "e-", 12: "νe", -13: "µ+", 13: "µ-", 14: "νµ",  # leptons
+          15: "τ-", 16: "ντ", 17: "τ'-", 18: "ντ'", 
+          21: "g", 22: "γ", 23: "Z0", 24: "W+", 37: "H+", 39: "G", # bosons, graviton
+          111: "π0", 211: "π+", -211: "π-", # light I = 0 mesons
+          321: "K+", # strange mesons
+          2112: "n", 2212: "p", 3112: "Σ−", 3122: "Λ", 3222: "Σ+", # light baryons, strange baryons
+          1000010020: "deuteron", 1000010030: "triton", 1000010040: "H4", 1000020030: "He3", 1000020040: "He4", 1000020060: "He6",
+          1000030040: 'Li4', 1000030060: 'Li6', 1000030070: 'Li7', 1000040080: 'Be8', 1000040090: 'Be9', 1000040100: 'Be10', 1000050080: 'B8', 1000050100: 'B10', 1000050110: 'B11', 1000060110: 'C11', 1000060120: 'C12', 1000060130: 'C13', 1000060140: 'C14', 1000070120: 'N12', 1000070140: 'N14', 1000070150: 'N15', 1000080160: 'O16', 1000080170: 'O17', 1000080180: 'O18', 1000080190: 'O19', 1000080200: 'O20', 1000090170: 'F17', 1000090180: 'F18', 1000090190: 'F19', 1000090200: 'F20', 1000100200: 'Ne20', 1000100210: 'Ne21', 1000100220: 'Ne22', 1000100230: 'Ne23', 1000100240: 'Ne24', 
+          1000110220: 'Na22', 1000110230: 'Na23', 1000110240: 'Na24', 1000110241: 'Na24', 1000110250: 'Na25', 1000120230: 'Mg23', 1000120240: 'Mg24', 1000120250: 'Mg25', 1000120260: 'Mg26', 1000120270: 'Mg27', 1000120280: 'Mg28', 1000130260: 'Al26', 1000130270: 'Al27', 1000130280: 'Al28', 1000130290: 'Al29', 1000130300: 'Al30', 1000130310: 'Al31', 1000140270: 'Si27', 1000140280: 'Si28', 1000140290: 'Si29', 1000140300: 'Si30', 1000140310: 'Si31', 1000140320: 'Si32', 1000140330: 'Si33', 1000150300: 'P30', 1000150310: 'P31', 1000150320: 'P32', 1000150330: 'P33', 1000150340: 'P34', 1000150350: 'P35', 1000150360: 'P36', 1000160320: 'S32', 1000160330: 'S33', 1000160340: 'S34', 1000160350: 'S35', 1000160360: 'S36', 1000160370: 'S37', 1000160380: 'S38', 1000170340: 'Cl34', 1000170350: 'Cl35', 1000170360: 'Cl36', 1000170370: 'Cl37', 1000170380: 'Cl38', 1000170389: 'Cl38', 1000170390: 'Cl39', 1000170400: 'Cl40', 1000180350: 'Ar35', 1000180360: 'Ar36', 1000180370: 'Ar37', 1000180380: 'Ar38', 1000180390: 'Ar39', 1000180400: "Ar40", 1000180410: 'Ar41', 1000190380: 'K38', 1000190390: 'K39', 1000190400: 'K40', 1000190410: 'K41'
+          }
+#atoms[proton number]
+atoms = "0,H,He,Li,Be,B,C,N,O,F,Ne,Na,Mg,Al,Si,P,S,Cl,Ar,K,Ca,Sc,Ti,V,Cr,Mn,Fe,Co,Ni,Cu,Zn,Ga,Ge,As,Se,Br,Kr".split(',')
+
+# ----------------------- Utility Functions ---------------------- #
+def nucleus_to_label(pdgId):
+    """
+    Returns "Ar40"-esque labels of atom + num baryons for nuclei
+    Labeling scheme from https://pdg.lbl.gov/2007/reviews/montecarlorpp.pdf
+        10LZZZAAAI  -- pdgId nuclear code
+        L = num lamba baryons
+        ZZZ = num protons = atomic number
+        AAA = total num baryons = protons + neutrons + lambda baryons
+        I = isomer number = excitation level, 0 for ground state
+    """
+    pdgId = str(pdgId)
+    if len(pdgId) != 10 or pdgId[0] != '1': 
+        print(f"pdgId {pdgId} is not a nucleus!")
+        return "N/A"
+     # str(int( removes leading zeroes.
+    L = pdgId[2]; Z = int(pdgId[3:6]); A = str(int(pdgId[6:9])); I = pdgId[9]
+    return atoms[Z]+A
+
+def tolerant_mean(arrays):
+    """
+    Returns a the moving average, max, and min of a numpy array of arrays 
+    """
+    lens = [arr.size for arr in arrays]
+    all_arr = np.ma.empty( (np.max(lens),len(arrays)) )
+    all_arr.mask = True
+    for idx, arr in enumerate(arrays):
+        all_arr[:lens[idx], idx] = arr
+    return all_arr.mean(axis = -1), all_arr.max(axis = -1), all_arr.min(axis = -1)
+
+def smooth(array, length): 
+    """
+    Smooths array over a length window just like scipy.uniform1d(array, length) while ignoring np.inf() values
+    """
+    l = len(array)
+    new_array = np.zeros(l)
+    for i in range(l):
+        mi = max(i-length//2, 0)  # min valid array
+        ma = min(i+length//2, l)  # max valid array
+        sub_array = array[mi:ma]
+        if mi == 0: # reflect at start # 0 1 2 3 4 5
+            sub_array = np.append(array[0:length//2 - i], sub_array)
+        if ma == l: # reflect at end
+            sub_array = np.append(sub_array, array[2*l - 1 - i - length//2:l])         
+        new_array[i] = np.mean(sub_array[sub_array != np.inf])  # ignore np.inf values
+    return new_array
+
+def movingavg(array):
+    l = len(array)
+    new_array = np.zeros(l)
+    for i in range(l):
+        sub_array = np.asarray(array[:i])
+        sub_array = sub_array[sub_array != np.inf]  # ignore np.inf values
+        sub_array = sub_array[sub_array != np.nan]
+        new_array[i] = np.sum(sub_array) / (i+1)
+    return new_array
+
+# ----------------- Plotting Functions ----------------- #
+def plot_losses(data, plot_name, unif_len, cut_to_min=False, print_info=False, label=None):
+    """
+    Plot the simulation loss, saved in data['loss']
+    """
+    if cut_to_min: # graph convergence on minimum iterations over all data
+        min_iterations = min([len(dat['loss']) for dat in data])
+    plt.figure(figsize=PLOT_FIGSIZE)
+    for count, dat in enumerate(data):
+        seed_init = dat['seed_init']; seed = dat['seed']; data_seed = dat['data_seed']
+        loss = dat['loss'][:min_iterations] if cut_to_min else dat["loss"]
+        l = f"seed {seed}" if label == 'seed' else (f"iseed {seed_init}" if label == "seed_init" else (f"dtseed {data_seed}" if data_seed else f"{seed}-{seed_init}-{data_seed}"))
+        if print_info: print(f"\tloss {l}: {loss[0]}-->{loss[-1]}")
+        plt.plot(loss, c=f'C{count}', linewidth=LINEWIDTH, label=l)
+        #plt.plot(len(loss)+40, np.mean(loss[-unif_len:]), marker='_', linewidth=LINEWIDTH, markersize=6)
+    l = f" Initial Seed {seed_init} " if label == 'seed' else (f" Seed {seed} " if label == "seed_init" else (f" Data Seed {data_seed} " if label == "data_seed" else ""))
+    plt.title(f"Loss{l}")
+    plt.ylabel('Simulation Loss')
+    plt.xlabel('Training Iteration')
+    plt.legend(loc='best', fontsize="10")
+    plt.tight_layout()
+    plt.savefig(plot_name, dpi=PLOT_DPI)
+    print(f'Saving plot to {plot_name}')
+    plt.close()
+
+def plot_params(data, plot_name, param, label=None):
+    """
+    Plot parameter iterations for data, stored in dat['data']['{paaram}_iter']
+    """
+    targets = []; label_target = False
+    plt.figure(figsize=PLOT_FIGSIZE)
+    for count, dat in enumerate(data):
+        # PLOT TARGET VALUE
+        target_val = dat['data'][f'{param}_target'][0]
+        if target_val not in targets: 
+            targets.append(target_val)
+            plt.plot([0, len(dat['data'][f"{param}_iter"])], [target_val]*2, c=f'C{count}', ls='dashed', label=("target: %.3e" % target_val if label_target else None), linewidth=LINEWIDTH*1.2)
+        # plot & label iteration
+        seed_init = dat['seed_init']; seed = dat['seed']; init_val = dat['data'][f"{param}_iter"][0]; data_seed = dat['data_seed']
+        l = f"seed {seed}" if label == 'seed' else ("initial val %.3e" % init_val if label == "seed_init" else (f"dtseed {data_seed}" if label == 'data_seed' else f"{seed}-{seed_init}-{data_seed}"))
+        plt.plot(dat['data'][f"{param}_iter"], c=f'C{count}', linewidth=LINEWIDTH, label=l)
+        plt.plot(0, init_val, c=f'C{count}', marker='_', linewidth=LINEWIDTH, markersize=12)
+    l = f"Initial Seed {seed_init} " if label == 'seed' else (f" Seed {seed} " if label == "seed_init" else (f" Data Seed {data_seed} " if label == "data_seed" else ""))
+    plt.title(f"{param} {l}Iterations")
+    plt.ylabel(f'Fitting {labels[param]}')
+    plt.xlabel('Training Iteration')
+    #plt.legend(loc='best', fontsize="10") # w/ legend ofc
+    plt.legend(bbox_to_anchor=(1.05, 1.0), loc='upper left')
+    plt.tight_layout()
+    plt.savefig(plot_name, dpi=PLOT_DPI)
+    print(f'Saving plot to {plot_name}')
+    plt.close()
+
+def plot_convergences(data, plot_name, plot_individual_convergences=True, cut_to_min=False, print_info=False, logy=True, label=None,
+                      iter_range=None):
+    """
+    Plot parameter convergence across all parameters in a run, stored in data['convergence']
+     - plot_name = name of the plot to be saved as plot_name.{config.ext}}
+     - plot_individual_convergences
+       = True will plot the convergence of each individual run along with average, min, & max
+       = False will only plot the average, min, & max convergence for the data
+     - cut_to_min
+       = True will only show convergences up to the minimum num of iterations in data
+       = False will show convergences and calculate average as moving average over all iterations in data
+     - print_info determines if initial -> final convergence info is printed for each run in data
+     - logy determines if plot has a logarithmic y axis or not
+     - label = 'seed' or 'seed_init' determines label description, if either data has same seed_init or same seed
+     - iter_range determines iteration (x) range to plot
+    """
+    if cut_to_min: # graph convergence on minimum iterations over all data
+        min_iterations = min([len(dat['convergence']) for dat in data])
+    plt.figure(figsize=PLOT_FIGSIZE)
+    if plot_individual_convergences:
+        for count, dat in enumerate(data):
+            seed = dat['seed']; seed_init = dat['seed_init']
+            conv = dat['convergence']
+            if print_info: print(f"convergence {seed}-{seed_init}: {conv[0]}-->{conv[-1]}")
+            l = f"seed {seed}" if label == 'seed' else (f"initial seed {seed_init}" if label == 'seed_init' else (f"data seed {data_seed}" if label == 'data_seed' else f"{seed}-{seed_init}-{data_seed}"))
+            if cut_to_min:
+                plt.plot(conv[:min_iterations], c=f'C{count}', linewidth=LINEWIDTH, label=l)
+            else:
+                plt.plot(conv, c=f'C{count}', linewidth=LINEWIDTH, label=l)
+    if cut_to_min:
+        avg_iter = np.mean(data['convergence'], 0)
+        max_iter = np.max(data['convergence'], 0)
+        min_iter = np.min(data['convergence'], 0)
+    else: # dynamically change min, max, avg
+        avg_iter, max_iter, min_iter = tolerant_mean(data['convergence'])
+    if not plot_individual_convergences:
+        plt.plot(min_iter, color='#6e77ff', linewidth=LINEWIDTH*0.5)
+        plt.plot(max_iter, color='#6e77ff', linewidth=LINEWIDTH*0.5)
+        plt.plot(avg_iter, color='red', linewidth=LINEWIDTH*2)
+    else:
+        plt.plot(avg_iter, label='avg', color='red', linewidth=LINEWIDTH*2, ls='dashed')
+        plt.legend(loc='best', fontsize='8')
+    plt.fill_between(range(len(avg_iter)), min_iter, max_iter, alpha=0.1, color='#6e77ff')
+    if logy: plt.yscale('log')
+    l = f" Initial Seed {data['seed_init'][0]}" if label == 'seed' else (f" Seed {data['seed'][0]}" if label == "seed_init" else (f" Data Seed {data['data_seed'][0]}" if label == "data_seed" else ""))
+    plt.title(f"Parameter Convergence{l}")
+    plt.ylabel(f'Convergence to Target Parameters [%]')
+    plt.xlabel('Training Iteration')
+    if iter_range is not None:
+        plt.xlim(iter_range)
+    #plt.ylim(np.min(min_iter), np.max(max_iter))  # fit y max, min to max, min of data
+    plt.tight_layout()
+    plt.savefig(plot_name, dpi=PLOT_DPI)
+    print(f'Saving plot to {plot_name}')
+    plt.close()
+
+def plot_elements(fname, print_info=False, xlog=True, ylog=True, nbins = 30, e_range=None):
+    # return tracks masked by element
+    elem_msk = lambda arr, e: [int(str(p)[3:6]) == e for p in arr['pdgId']]
+    
+    # get file, tracks
+    if print_info: print(f'getting {fname}, {files_dict[fname]}')
+    hfile = h5py.File(files_dict[fname])
+    tracks = hfile['segments']
+    # cut tracks to energy range & only nuclei
+    if e_range == None:
+        e_range = [1e-10,1e10] if xlog else [0,100]
+    if print_info: print(tracks.size,"total tracks")
+    tracks = tracks[np.logical_and(tracks['dEdx'] < e_range[1], tracks['dEdx'] > e_range[0])]
+    tracks = tracks[tracks['pdgId'] > 1e6]
+    
+    # get particles & sort by descending number of counts
+    nuclei, counts = np.unique(tracks['pdgId'], return_counts=True)
+    nuclei = nuclei.tolist() # dont include '0' particle
+    if len(nuclei) == 0:
+        sys.exit("No nuclei found in "+fname+"!")
+    nuclei.sort(reverse=True, key=lambda n: tracks[tracks['pdgId'] == n].size)
+    elements = np.unique([int(str(p)[3:6]) for p in tracks['pdgId']]).tolist()
+    elements.sort(reverse=True, key=lambda e: tracks[elem_msk(tracks, e)].size)
+    if print_info: 
+        print(tracks.size,"nuclei tracks")
+        print(f"nuclei found in {fname}: "+", ".join(f"{pdgIds[nuclei[i]]}-{counts[i]}" for i in range(len(nuclei))))
+    print(f"elements in {fname}: "+", ".join(atoms[e] for e in elements))
+    # plot!
+    plt.figure(figsize=PLOT_FIGSIZE)
+    min_e = np.min(tracks['dEdx'])
+    max_e = np.max(tracks['dEdx'])
+    if xlog: # set plot xlog, ylog
+        plt.xscale('log')
+        bins = np.logspace(np.log10(min_e), np.log10(max_e), nbins)
+    else:
+        bins = np.linspace(min_e, max_e, nbins)
+    if ylog: # want to see all particles
+        plt.yscale('log')
+    else:  
+        elements = elements[::-1]
+    
+    for c, element in enumerate(elements):
+        if print_info: print(f"plotting {element_name} {count}")
+        element_name = atoms[element]
+        energies = tracks[elem_msk(tracks, element)]['dEdx']
+        count = energies.size
+        if not ylog: c = len(elements) - 1 - c
+        #weight = [1/ncounts[c]]*counts[c] if normalize else None
+        plt.hist(energies, bins=bins, color=f"C{c}", alpha=1, label=f"{element_name}: {count}", stacked=True)
+    plot_name = f"plot_dEdx_{fname}_elements_{('T' if xlog else 'F')}{('T' if ylog else 'F')}_{nbins}.png"
+    plt.xlabel("dE/dx [MeV/cm]")
+    plt.ylabel("# of entries")
+    plt.title(f"{fname} elements dEdx, MeV/cm")
+    plt.legend(bbox_to_anchor=(1.05, 1.0), loc='upper left')
+    plt.tight_layout()
+    plt.savefig(plot_name, dpi=PLOT_DPI)
+    print("Saved plot to",plot_name,"\n")
+    plt.close()
+
+# plot particles, stacked, for a file. plot one for nucleus, one for not
+def plot_particle_dEdxs(fname, xlog=True, ylog=True, nbins = 30, e_range=None, nuclei=None, print_info=False):
+    # get file, tracks
+    if print_info: print(f'getting {fname}, {files_dict[fname]}')
+    hfile = h5py.File(files_dict[fname])
+    tracks = hfile['segments']
+    # cut tracks to energy range
+    if e_range == None:
+        e_range = [1e-10,1e10] if xlog else [0,100]
+    tracks = tracks[np.logical_and(tracks['dEdx'] < e_range[1], tracks['dEdx'] > e_range[0])]
+    # cut tracks to include or exclude nuclei
+    add = "all"
+    if nuclei: # plot only nuclei
+        tracks = tracks[tracks['pdgId'] > 1e6]
+        add = "nuclei"
+    elif nuclei == False: # plot only non-nuclei
+        tracks = tracks[tracks['pdgId'] < 1e6]
+        add = "no-nuclei"
+    # get particles & sort by descending number of counts
+    particles = np.subtract(np.unique(tracks['pdgId']), np.array([0])).tolist() # dont include '0' particle
+    particles.sort(reverse=True, key=lambda p: tracks[tracks['pdgId'] == p].size)
+    print(f"particles found in {fname}: "+", ".join(pdgIds[p] for p in particles))
+
+    # begin plotting
+    min_e = np.min(tracks['dEdx'])
+    max_e = np.max(tracks['dEdx'])
+    plt.figure(figsize=PLOT_FIGSIZE)
+    if xlog: # set plot xlog, ylog
+        plt.xscale('log')
+        bins = np.logspace(np.log10(min_e), np.log10(max_e), nbins)
+    else:
+        bins = np.linspace(min_e, max_e, nbins)
+    if ylog: # want to see all particles
+        plt.yscale('log')
+    else:  
+        particles = particles[::-1]
+    # plot all particles
+    for c, p in enumerate(particles):
+        #print(f"plotting {pdgIds[p]}")
+        if not ylog: c = len(particles) - c - 1
+        energies = tracks[tracks['pdgId'] == p]['dEdx']
+        count = energies.size
+        #weight = [1/ncounts[c]]*counts[c] if normalize else None
+        plt.hist(energies, bins=bins, color=f'C{c}', alpha=1, label=f"{pdgIds[p]}: {count}", stacked=True)
+    fadd = ''.join([''.join([j[0] for j in i.split(' ')]) for i in fname.split('_')])
+    plot_name = f"plot_dEdx_{fadd}_particles-{add}_{('T' if xlog else 'F')}{('T' if ylog else 'F')}_{nbins}.png"
+    plt.xlabel("dE/dx [MeV/cm]")
+    plt.ylabel("# of entries")
+    plt.title(f"{fname} {add} particles dEdx, MeV/cm")
+    plt.legend(loc='best')
+    #plt.legend(bbox_to_anchor=(1.05, 1.0), loc='upper left')
+    plt.savefig(plot_name, dpi=PLOT_DPI)
+    print("Saved plot to",plot_name,"\n")
+    plt.close()
+
+# Plot dEdxs comparing one or more edepsim-style h5 files
+# if plot_particles, will make plots comparing each file 
+#                        for each particle in both files
+# normalize = normalize histogram counts relative to size of each set
+def plot_dEdxs(fnames, plot_particles=False, print_info=False, normalize=True,
+               xlog=False, ylog=True, nbins = 30, e_range=None):
+    label_max_bin = False
+    numfiles = len(fnames)
+    hfiles = np.empty((numfiles,),dtype='object')
+    tracks = np.empty((numfiles,),dtype='object')
+    energies = np.empty((numfiles,),dtype='object')
+    ncounts = np.empty((numfiles,),dtype='object')
+    if e_range is None:
+        e_range = [1e-4,1e10] if xlog else [0,100]
+    
+    for c, f in enumerate(fnames):
+        hfiles[c] = h5py.File(files_dict[f])
+        tracks[c] = hfiles[c]['segments']
+        e_msk = np.logical_and(tracks[c]['dEdx'] < e_range[1],tracks[c]['dEdx'] > e_range[0])
+        tracks[c] = tracks[c][e_msk]
+    # get list of all particles among all files
+    fadd = '.'.join([''.join([''.join([j[0] for j in i.split(' ')]) for i in f.split('_')]) for f in fnames])
+    plot_name = f"plot_dEdx_{fadd}_{('T' if xlog else 'F')}{('T' if ylog else 'F')}_{nbins}{('N' if normalize else '')}.png"
+    
+    cmsk = [c for c in range(numfiles)]
+    uniq_particle_list = ['nah']
+    if plot_particles:
+        cmsk = [c for c in range(numfiles) if 'pdgId' in tracks[c].dtype.names]
+        print(cmsk)
+        if len(cmsk):
+            p = np.concatenate([tracks[c]['pdgId'] for c in cmsk])
+            uniq_particle_list = np.subtract(np.unique(p), np.array([0]))
+            # print new particles found so I can add them to pdgId list 
+            pp = False 
+            for p in uniq_particle_list:
+                if p not in pdgIds.keys():
+                    pp = True
+                    pdgIds[p] = nucleus_to_label(p)
+            if pp: print(pdgIds)
+            print("particles found: "+", ".join(pdgIds[p] for p in uniq_particle_list))
+        else:
+            print('no files',' ,'.join(fnames),'have pdgIds.\n quitting now...')
+            sys.exit()
+    
+    tracks_ = tracks.copy()
+    for c in cmsk: ncounts[c] = tracks[c]['dEdx'].size # counts to normalize datasets
+    counts = ncounts.copy()
+    for particle in uniq_particle_list:
+        # # # SET TRACKS (CUTTING FOR PARTICLE TRACKS) # # # #
+        cmsk2 = [c for c in cmsk]
+        if plot_particles: # CUT TO ONLY TRACKS WITH PARTICLE & within energy range
+            cmsk2 = []
+            for c in cmsk:
+                msk = tracks[c]['pdgId'] == particle
+                tracks_[c] = tracks[c][msk]
+                if print_info: print(f"resized {tracks[c].size}-->{tracks_[c].size}")
+                if tracks_[c].size > 0:
+                    cmsk2.append(c)
+            if len(cmsk2) < 2: continue
+            plot_name = f"plot_dEdx_{fadd}_{pdgIds[particle]}_{('T' if xlog else 'F')}{('T' if ylog else 'F')}_{nbins}{('N' if normalize else '')}'.png"
+        # # # SET ENERGIES AND COUNTS # # #
+        for c in cmsk2:
+            energies[c] = tracks_[c]['dEdx']
+            counts[c] = energies[c].size
+        add = pdgIds[particle]+" " if plot_particles else ""
+        if print_info:
+            string = ', '.join([ fnames[c]+"-"+str(np.sum(tracks_[c]['dx'])) for c in cmsk2])
+            print(f"all {add}segments length: {string}")
+            string = ', '.join([ fnames[c]+"-"+str(np.sum(energies[c])) for c in cmsk2])
+            print(f"total {add}dEdx: {string}")
+            string = ', '.join([ fnames[c]+"-"+str(counts[c]) for c in cmsk2])
+            print(f"number of {add}segments: {string}")
+        all_e = np.concatenate([energies[c] for c in cmsk2])
+        #print(len(all_e), all_e.shape)
+        min_e = np.min(all_e)
+        max_e = np.max(all_e)
+        #print(f"energy range: {min_e}<-->{max_e}")
+        plt.figure(figsize=PLOT_FIGSIZE)
+        if xlog: # set plot xlog, ylog
+            plt.xscale('log')
+            logbins = np.logspace(np.log10(min_e),np.log10(max_e),nbins)
+        else:
+            logbins = np.linspace(min_e,max_e,nbins)
+        if ylog: plt.yscale('log')
+
+        # PLOT NORMALIZED HISTOGRAM OF ENERGIES FOR ALL FILES
+        for c in cmsk2: 
+            weight = [1/ncounts[c]]*counts[c] if normalize else None
+            (n, bins, patches) = plt.hist(np.asarray(energies[c]), bins=logbins, weights=weight, 
+                                          color=f'C{c}', alpha=0.5, label=f"{fnames[c]}: {counts[c]}")
+            if label_max_bin:
+                max_counts_idx = max([i for i in range(len(n))], key = lambda x: n[x])
+                patch = patches[max_counts_idx]
+                label = "%.2e" % n[max_counts_idx] if normalize else str(n[max_counts_idx]).split('.')[0]
+                plt.text(patch.get_x() + patch.get_width() / 2, patch.get_height()+0.01, label,
+                    ha='center', va='bottom')  # ADD LABEL TO MAX BIN IN FILE
+        
+        plt.xlabel("dE/dx [MeV/cm]")
+        add = "normalized " if normalize else ""
+        plt.ylabel(f"{add}# of entries")
+        string = ' vs. '.join([fnames[c] for c in cmsk2])
+        msk = pdgIds[particle]+" " if plot_particles else ""
+        plt.title( f"{string} {msk}dEdx counts in MeV/cm" )
+        plt.legend(loc='best')
+        plt.savefig(plot_name, dpi=PLOT_DPI)
+        print("Saved plot to",plot_name,"\n")
         plt.close()
+
+# —.——.———.———.———.———.———.———.———.———.———.———.———.———.———.———.———.———.—————————.———.——————————————————————————————————————————
+# ——.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.—.——————————————————————————————————————————
+# ———.———.———.———.———.———.———.———.———.———.———.———.———.———.———.———.———.———.—.—.—.———.———————————————————————————————————————————
+def main(config):
+    config.plot = [t.lower() for t in config.plot]
+    global LINEWIDTH, PLOT_DPI, PLOT_FIGSIZE
+    LINEWIDTH    = config.linewidth if config.linewidth else .8
+    PLOT_DPI     = 600
+    PLOT_FIGSIZE = (6.4, 4.8) # default matplotlib figure size
+    # google slides is PLOT_FIGSIZE = (10, 5.625)
+    # significant number of seeds having one seed_init 
+    #   to plot for a single seed_init, & vice versa for seeds 
+    sig_num_to_plot = 3
+    cut_to_min      = False  # cut graphs to minimum value?
+    print_info      = True   # print more info while plotting?
+    # GET UNIF_LEN FOR LOSSES SMOOTHING
+    UNIF_LEN = int(config.plot[config.plot.index('loss')+1]) if config.plot[config.plot.index('loss')+1].isdigit() else 320
+    # smooth with moving average of loss after smoothing with uniform?
+    # (avg[loss[:i] for i in loss])
+    do_moving_avg = 'avg' in config.plot[config.plot.index('loss')+1:min(config.plot.index('loss')+3,len(config.plot))]
+   
+    if "dedx" in config.plot:
+        PLOT_FIGSIZE = (8,4.8)
+        # number of histogram bins specified after dedx or default 200
+        NUM = int(config.plot[config.plot.index('dedx')+1]) if config.plot[config.plot.index('dedx')+1].isdigit() else 200
+       
+        for f in ['dEdx > 5', 'dEdx < 2']:
+            for log_combo in [(True, True), (False, False), (False, True)]: #(xlog, ylog)
+                #plot_elements(f, xlog=log_combo[0], ylog=log_combo[1], nbins = NUM)
+                plot_particle_dEdxs(f, xlog=log_combo[0], ylog=log_combo[1], nbins = NUM)
+                #plot_dEdxs(['dEdx > 5', 'dEdx < 2'], xlog=log_combo[0], ylog=log_combo[1], nbins=NUM, normalize=True, 
+                #           e_range=[1e-4,1e10], plot_particles=False)
+        sys.exit() # dont look at any pickle data
+     
+
+    # -------------- LOAD DATA FROM .pkl FILES --------------------------------
+    data_entry = np.dtype([('seed', 'i4'),('seed_init', 'i4'),('data_seed', 'i4'),('data', 'O'),('convergence', 'O'),('loss', 'O')])
+    data = np.array([], dtype=data_entry)
+
+    fnames = []
+    for seed in config.seeds:
+        # search for all relevant seeds
+        for start in ['history', 'losses']:
+            if seed == -1: # no seeds specified
+                # get all relevant files regardless of seed
+                fnames.extend(glob(f"{start}*{config.label}*.pkl"))
+            else: 
+                # try various combinations of seed, config_label
+                for slabel in ['_dtseed','_seed','i=seed','i=dtseed']:
+                    fnames.extend(glob(f'{start}*{slabel}{seed}_*{config.label}*.pkl'))
+                    fnames.extend(glob(f'{start}*{config.label}_*{slabel}{seed}*.pkl'))
+    fnames = list(set(fnames)) # dont repeat any filenames
+        
+    for f in fnames: 
+        history = pickle.load(open(f, "rb"))
+        # get seed, init_seed, and data_seed
+        
+        data_seed = 0
+        if 'config' in history.keys():
+            seed = history['config'].seed; seed_init = history['config'].seed_init; data_seed = history['config'].data_seed
+        elif 'seed' in history.keys():
+            seed = history['seed']; seed_init = history['seed_init']; data_seed = history['data_seed']
+        else: # get seeds from filename lol
+            if 'i=dt_seed' in f:
+                seed = seed_init = f.split('i=dt_seed')[1][0]
+            if 'i=seed' in f:
+                seed = seed_init = f.split('i=seed')[1][0]
+                if 'dtseed' in f:
+                    data_seed = f.split('dtseed')[1][0]
+            if 'iseed' in f:
+                seed_init = f.split('iseed')[1][0]
+        # get params
+        if len(config.params) == 0: # if no --params label, automatically use all params available
+            config.params = np.unique([key.split('_iter')[0] for key in history.keys() if key.split('_iter')[0] in labels])
+            print('Params found:',', '.join(config.params))
+        
+        # STORE SMOOTHED LOSS IN dat['loss']
+        loss = np.array(history['losses_iter'])
+        if data_seed == 6: print(loss)
+        if UNIF_LEN > 0:  loss = smooth(loss, UNIF_LEN) # smooth loss!
+        if do_moving_avg: loss = movingavg(loss)
+
+        # STORE PARAMETER CONVERGENCE dat['convergence']
+        try: # if history[f"{param}_iter"] is stored as a single value
+            float(history[f"{config.params[0]}_iter"])
+            size = int(loss.size)
+            norm_iters = np.zeros((len(config.params), size))
+            for c, param in enumerate(config.params):
+                norm_iters[c] = [abs(history[f"{param}_iter"] - history[f"{param}_target"])/history[f"{param}_target"]]*size
+        except TypeError:
+            min_iterations = min([len(history[f"{param}_iter"]) for param in config.params])
+            norm_iters = np.zeros((len(config.params), min_iterations))
+            for c, param in enumerate(config.params):
+                norm_iters[c] = (abs(np.array(history[f"{param}_iter"]) - history[f'{param}_target'][0])/history[f'{param}_target'][0])[:min_iterations]
+            
+        if config.convergence == 'max':
+            convergence = np.max(norm_iters, 0)
+        elif config.convergence == 'sum':
+            convergence = np.sum(norm_iters, 0)
+        elif config.convergence == 'min':
+            convergence = np.min(norm_iters, 0)
+        elif config.convergence == 'mean':
+            convergence = np.mean(norm_iters, 0)
+        
+        entry = np.array([(seed, seed_init, data_seed, history, convergence, loss)], dtype=data_entry)
+        data = np.append(data, entry)
+   
+    if data.shape == (0,):
+        sys.exit(f"Error: found no .pkl files in {os.getcwd()} with label '{config.label}' and seeds {config.seeds}")
+    print("Data found: "+', '.join([f"{dat['seed']}-{dat['seed_init']}"+(f"-{dat['data_seed']}" if data_seed else "") for dat in data]))
+    
+    seed_inits = np.unique(data['seed_init'])
+    seeds = np.unique(data['seed'])
+    data_seeds = np.unique(data['data_seed'])
+    msk = [len(data[data['seed'] == seed]) >= sig_num_to_plot for seed in seeds]
+    msk1 = [len(data[data['seed_init'] == seed_init]) >= sig_num_to_plot for seed_init in seed_inits]
+    msk2 = [len(data[data['data_seed'] == data_seed]) >= sig_num_to_plot for data_seed in data_seeds]
+    plot_seeds = seeds[msk]
+    plot_inits = seed_inits[msk1]
+    plot_dtseeds = data_seeds[np.logical_and(msk2, [d != 0 for d in data_seeds])]
+    # now use label for plotting purposes
+    config.label = config.label + f"_seeds{'-'.join([str(s) for s in seeds])}"+config.label_add
+    # multiple runs for each seed (varying initial condition), plot 
+    # plot each param, showing iterations of all seeds ran
+
+    # -------------------------- CALL PLOTTING SCRIPTS ---------------------------------------
+    # plot simulation losses
+    if 'loss' in config.plot:
+        add = "-avg" if do_moving_avg else ""
+        PLOT_FIGSIZE = (8,4.8)
+        # PLOT INITIAL VALUE w/ MULT SEEDS
+        for seed_init in plot_inits: 
+            plot_losses(data[data['seed_init'] == seed_init], 
+                        f"plot_loss{add}_iseed{seed_init}_{UNIF_LEN}_{config.label}.{config.ext}", UNIF_LEN, 
+                        print_info = print_info, label='seed', cut_to_min=cut_to_min)
+        # PLOT MULT INITAL VALUES per SEED
+        for seed in plot_seeds: 
+            plot_losses(data[data['seed'] == seed], 
+                        f"plot_loss{add}_seed{seed}_{UNIF_LEN}_{config.label}.{config.ext}", UNIF_LEN, 
+                        print_info = print_info, label='seed_init', cut_to_min=cut_to_min)
+        for data_seed in plot_dtseeds: 
+            plot_losses(data[data['data_seed'] == data_seed], 
+                        f"plot_loss{add}_dtseed{data_seed}_{UNIF_LEN}_{config.label}.{config.ext}", UNIF_LEN, 
+                        print_info = print_info, label='', cut_to_min=cut_to_min)
+        # PLOT ALL LOSSES
+        if len(plot_inits) + len(plot_seeds) + len(plot_dtseeds) != 1:
+            plot_losses(data, f"plot_loss{add}_{UNIF_LEN}_{config.label}.{config.ext}", UNIF_LEN, 
+                        print_info = print_info, cut_to_min=cut_to_min)
+
+    # plot parameter iterations
+    if 'all' in config.plot or "param" in config.plot:
+        for param in config.params: 
+            # VARYING INITIAL VALUE CONVERGING TO ONE TARGET, per SEED
+            for seed in plot_seeds:
+                plot_name = f'plot_vary-init_{param}_seed{seed}_{config.label}.{config.ext}'
+                plot_params(data[data['seed'] == seed], plot_name, param, 'seed_init')
+            # MULTIPLE TARGETS / SEEDS, ONE PLOT per initial seed
+            for seed_init in plot_inits:  # only works for repeat !!!!!
+                plot_name = f'plot_vary-seed_{param}_iseed{seed_init}_{config.label}.{config.ext}'
+                plot_params(data[data['seed_init'] == seed_init], plot_name, param, 'seed')
+            
+            if len(plot_inits) + len(plot_seeds) != 1:
+                plot_name = f'plot_{param}_{config.label}.{config.ext}'
+                plot_params(data, plot_name, param)
+
+    # plot parameter convergences
+    if "convergence" in config.plot or "conv" in config.plot:
+        logy = False
+        #iter_range=[4500,5000] # determines range of x values to plot
+        iter_range=None
+        for logy in [False, True]:
+            for plot_individual_convergences in [False, True]: 
+                add = "-all" if plot_individual_convergences else ""
+                add += "-regy" if not logy else ""
+
+                for seed_init in plot_inits:
+                    plot_name = f"plot_{config.convergence}{add}_iseed{seed_init}_{config.label}.{config.ext}"
+                    plot_convergences(data[data['seed_init'] == seed_init], plot_name, plot_individual_convergences, cut_to_min, print_info, logy, 'seed', iter_range)
+                
+                for seed in plot_seeds:
+                    plot_name = f"plot_{add}{config.convergence}_seed{seed}_{config.label}.{config.ext}"
+                    plot_convergences(data[data['seed'] == seed], plot_name, plot_individual_convergences, cut_to_min, print_info, logy, 'seed_init', iter_range)
+                for data_seed in plot_dtseeds: 
+                    plot_name = f"plot_{add}{config.convergence}_dtseed{data_seed}_{config.label}.{config.ext}"
+                    plot_convergences(data[data['data_seed'] == data_seed], plot_name, plot_individual_convergences, cut_to_min, print_info, logy, 'data_seed', iter_range)
+                # plot all convergences if we havent plotted anything yet or have plotted more than one graph
+                if len(plot_inits) + len(plot_seeds) + len(plot_dtseeds) != 1: 
+                    plot_name = f"plot_{add}{config.convergence}_all_{config.label}.{config.ext}"
+                    plot_convergences(data, plot_name, plot_individual_convergences, cut_to_min, print_info, logy, iter_range)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument("--params", dest="params", default=[], nargs="+",
                         help="List of parameters to plot.")
-    parser.add_argument("--label", dest="label",
-                        help="Label of pkl file.") 
-    parser.add_argument("--seeds", dest="seeds", default=[], nargs="+",
+    parser.add_argument("--label", dest="label", default="",
+                        help="Label of pkl file (after seed part).") 
+    parser.add_argument("--seeds", dest="seeds", default=[-1], nargs="+",
                         help="List of target seeds to plot.") 
-    parser.add_argument("--ext", dest="ext", default="pdf",
+    parser.add_argument("--ext", dest="ext", default="png",
                         help="Image extension (e.g., pdf or png)") 
-
+    parser.add_argument("--convergence", dest='convergence', default='max',
+                        help="How normalized parameter iterations are combined into a total convergence level: 'sum', 'max', 'min', 'mean'")
+    parser.add_argument("--plot", dest='plot', default=[], nargs="+",
+                        help="List of plot specifications: \nloss [UNIF_LEN] [avg]: make loss plots, [int length for smoothing] [make moving average loss plot] \nall: plot parameter iterations, \
+                              \nconv: make parameter convergence plots\n dedx [NUM_BINS]: make histogram of energy data [int number of histogram bins], edit configurations in main() 471 \
+                              ")
+    parser.add_argument("--linewidth", dest='linewidth', default=None,
+                        help="List of plot specifications: \nloss: make loss plots, \nall: plot parameter iterations, \nconvergence: make parameter convergence plots")
+    parser.add_argument("--ladd", dest='label_add', default='',
+                        help="List of plot specifications: \nloss: make loss plots, \nall: plot parameter iterations, \nconvergence: make parameter convergence plots")
     args = parser.parse_args()
     main(args)

--- a/optimize/dataio.py
+++ b/optimize/dataio.py
@@ -5,6 +5,7 @@ from torch.utils.data import Dataset
 from numpy.lib import recfunctions as rfn
 import random
 import logging
+import sys
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -16,50 +17,63 @@ def torch_from_structured(tracks):
 def structured_from_torch(tracks_torch, dtype):
     return rfn.unstructured_to_structured(tracks_torch.cpu().numpy(), dtype=dtype)
 
-
-
 class TracksDataset(Dataset):
-    def __init__(self, filename, ntrack, max_nbatch=None, swap_xz=True, seed=3, random_ntrack=False, track_len_sel=2., 
-                 max_abs_costheta_sel=0.966, min_abs_segz_sel=15., track_z_bound=28., max_batch_len=None, print_input=False):
+    def __init__(self, filename, ntrack, max_nbatch=None, swap_xz=True, seed=3, random_ntrack=False, 
+                 track_len_sel=2.,max_abs_costheta_sel=0.966, min_abs_segz_sel=15., track_z_bound=28., max_batch_len=None, 
+                 print_input=False, preload=False):
+        
+        if not preload: 
+            # load file and cut data per usual
+            with h5py.File(filename, 'r') as f:
+                tracks = np.array(f['segments'])
 
-        with h5py.File(filename, 'r') as f:
-            tracks = np.array(f['segments'])
+            if swap_xz:
+                x_start = np.copy(tracks['x_start'] )
+                x_end = np.copy(tracks['x_end'])
+                x = np.copy(tracks['x'])
 
-        if swap_xz:
-            x_start = np.copy(tracks['x_start'] )
-            x_end = np.copy(tracks['x_end'])
-            x = np.copy(tracks['x'])
+                tracks['x_start'] = np.copy(tracks['z_start'])
+                tracks['x_end'] = np.copy(tracks['z_end'])
+                tracks['x'] = np.copy(tracks['z'])
 
-            tracks['x_start'] = np.copy(tracks['z_start'])
-            tracks['x_end'] = np.copy(tracks['z_end'])
-            tracks['x'] = np.copy(tracks['z'])
+                tracks['z_start'] = x_start
+                tracks['z_end'] = x_end
+                tracks['z'] = x
 
-            tracks['z_start'] = x_start
-            tracks['z_end'] = x_end
-            tracks['z'] = x
-
+            # flat index for all reasonable track [eventID, trackID] 
+            index = []
+            all_tracks = []
+            for ev in np.unique(tracks['eventID']):
+                track_set = np.unique(tracks[tracks['eventID'] == ev]['trackID'])
+                for trk in track_set:
+                    trk_msk = (tracks['eventID'] == ev) & (tracks['trackID'] == trk)
+                    xd = tracks[trk_msk]['x_start'][0] - tracks[trk_msk]['x_end'][-1]
+                    yd = tracks[trk_msk]['y_start'][0] - tracks[trk_msk]['y_end'][-1]
+                    zd = tracks[trk_msk]['z_start'][0] - tracks[trk_msk]['z_end'][-1]
+                    z_dir = [0,0,1]
+                    trk_dir = [xd, yd, zd]
+                    # selection criteria: track length, track direction not in z, max z comp not too high-->
+                    #                     now select only segments in track that arent nuclei and above min z
+                    #TODO once we enter the end game, this track selection requirement needs to be more accessible.
+                        # For now, we keep it as it is to take consistent data among developers
+                    if np.sum(tracks[trk_msk]['dx']) > track_len_sel:
+                        cos_theta = abs(np.dot(trk_dir, z_dir))/ np.linalg.norm(trk_dir)
+                        if max(abs(tracks[trk_msk]['z'])) < track_z_bound and abs(cos_theta) < max_abs_costheta_sel:
+                            msk = np.logical_and(abs(tracks[trk_mask]['z']) > min_abs_segz_sel, tracks[trk_mask]['pdgId'] < 1e6)
+                            num_new_tracks = len(tracks[trk_mask][msk])
+                            if num_new_tracks > 0:  # continue if masked tracks are nonzero
+                                index.append([ev, trk])
+                                all_tracks.append(torch_from_structured(tracks[trk_mask][msk]))
+        
+        else: 
+            # preloaded data that has been prepared using /sdf/home/b/bkroul/larnd-sim/read_lines.py
+            # read_lines.py --f path/to/h5py_to_read.h5 --mode cut
+            with h5py.File(filename, 'r') as f:
+                tracks = np.array(f['segments'])
+                index = np.array(f['index'])
+                all_tracks = [torch.from_numpy(np.array([tracks_np])).float() for tracks_np in np.array(f['all_tracks'])]
+        
         self.track_fields = tracks.dtype.names
-
-        # flat index for all reasonable track [eventID, trackID] 
-        index = []
-        all_tracks = []
-        for ev in np.unique(tracks['eventID']):
-            track_set = np.unique(tracks[tracks['eventID'] == ev]['trackID'])
-            for trk in track_set:
-                trk_msk = (tracks['eventID'] == ev) & (tracks['trackID'] == trk)
-                xd = tracks[trk_msk]['x_start'][0] - tracks[trk_msk]['x_end'][-1]
-                yd = tracks[trk_msk]['y_start'][0] - tracks[trk_msk]['y_end'][-1]
-                zd = tracks[trk_msk]['z_start'][0] - tracks[trk_msk]['z_end'][-1]
-                z_dir = [0,0,1]
-                trk_dir = [xd, yd, zd]
-                if np.sum(tracks[trk_msk]['dx']) > track_len_sel:
-                    cos_theta = abs(np.dot(trk_dir, z_dir))/ np.linalg.norm(trk_dir)
-                #TODO once we enter the end game, this track selection requirement needs to be more accessible.
-                # For now, we keep it as it is to take consistent data among developers
-                if np.sum(tracks[trk_msk]['dx']) > track_len_sel and max(abs(tracks[trk_msk]['z'])) < track_z_bound and abs(cos_theta) < max_abs_costheta_sel:
-                    index.append([ev, trk])
-                    all_tracks.append(torch_from_structured(tracks[trk_msk][abs(tracks[trk_msk]['z']) > min_abs_segz_sel]))
-
         # all fit with a sub-set of tracks
         fit_index = []
         fit_tracks = []
@@ -80,7 +94,7 @@ class TracksDataset(Dataset):
             for i_rand in list_rand:
                 fit_index.append(index[i_rand])
                 fit_tracks.append(all_tracks[i_rand])
-
+        
         if print_input:
             logger.info(f"training set [ev, trk]: {fit_index}")
       
@@ -144,4 +158,3 @@ class TracksDataset(Dataset):
         
     def get_track_fields(self):
         return self.track_fields
-

--- a/optimize/example_run.py
+++ b/optimize/example_run.py
@@ -2,6 +2,8 @@
 
 import logging
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 import argparse
 import yaml
@@ -11,12 +13,9 @@ from torch.utils.data import DataLoader
 import json
 import numpy as np
 
-
 from .fit_params import ParamFitter
 from .dataio import TracksDataset
 
-logger = logging.getLogger(__name__)
-logger.setLevel(logging.INFO)
 
 def make_param_list(config):
     if len(config.param_list) == 1 and os.path.splitext(config.param_list[0])[1] == ".yaml":
@@ -43,7 +42,8 @@ def main(config):
             max_nbatch = iterations
 
     dataset = TracksDataset(filename=config.input_file, ntrack=config.data_sz, max_nbatch=max_nbatch, seed=config.data_seed, random_ntrack=config.random_ntrack, 
-                            track_len_sel=config.track_len_sel, max_abs_costheta_sel=config.max_abs_costheta_sel, min_abs_segz_sel=config.min_abs_segz_sel, track_z_bound=config.track_z_bound, max_batch_len=config.max_batch_len, print_input=config.print_input)
+                            track_len_sel=config.track_len_sel, max_abs_costheta_sel=config.max_abs_costheta_sel, min_abs_segz_sel=config.min_abs_segz_sel, track_z_bound=config.track_z_bound, max_batch_len=config.max_batch_len, print_input=config.print_input,
+                            preload=config.preload)
 
     batch_sz = config.batch_sz
     if config.max_batch_len is not None and batch_sz != 1:
@@ -55,6 +55,7 @@ def main(config):
                                   batch_size=batch_sz,
                                   pin_memory=True, num_workers=config.num_workers)
 
+    # initialize simulation
     # For readout noise: no_noise overrides if explicitly set to True. Otherwise, turn on noise
     # individually for target and guess
     param_list = make_param_list(config)
@@ -72,6 +73,7 @@ def main(config):
                             set_target_vals=config.set_target_vals, vary_init=config.vary_init, seed_init=config.seed_init,
                             config = config)
     param_fit.make_target_sim(seed=config.seed, fixed_range=config.fixed_range)
+    # run simulation
     param_fit.fit(tracks_dataloader, epochs=config.epochs, iterations=iterations, shuffle=config.data_shuffle, save_freq=config.save_freq)
 
     return 0, 'Fitting successful'
@@ -171,6 +173,8 @@ if __name__ == '__main__':
                         help="Optimize the pixel chunk size to reach the specified GPU memory per batch, in MiB")
     parser.add_argument("--skip_pixels", dest="skip_pixels", default=False, action="store_true",
                         help="Iterating only over the pixels of each track (no cartesian product of all pixels x all tracks)")
+    parser.add_argument("--preload", dest="preload", default=False, action="store_true", 
+                        help="If input file contains tracks already cut to dataio standards")
 
     try:
         args = parser.parse_args()

--- a/optimize/loss_landscape.py
+++ b/optimize/loss_landscape.py
@@ -6,42 +6,97 @@ import traceback
 from torch.utils.data import DataLoader
 import matplotlib.pyplot as plt
 import pickle
+import yaml, json
 
 from .fit_params import ParamFitter
 from .dataio import TracksDataset
 
+import logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+def make_param_list(config):
+    if len(config.param_list) == 1 and os.path.splitext(config.param_list[0])[1] == ".yaml":
+        with open(config.param_list[0], 'r') as config_file:
+            config_dict = yaml.load(config_file, Loader=yaml.FullLoader)
+        for key in config_dict.keys():
+            logger.info(f"Setting lr {config_dict[key]} for {key}")
+        param_list = config_dict
+    else:
+        param_list = config.param_list
+    return param_list
+
 def main(config):
-    dataset = TracksDataset(filename=config.input_file, ntrack=config.data_sz, seed=config.data_seed, random_ntrack=config.random_ntrack, track_zlen_sel=config.track_zlen_sel)
+    if config.print_input: 
+        logger.info(f"fit label: {config.out_label}")
+
+    # format iterations
+    iterations = config.iterations
+    max_nbatch = config.max_nbatch
+
+    if iterations is not None:
+        if max_nbatch is None or iterations < max_nbatch or max_nbatch < 0:
+            max_nbatch = iterations
+    
+    # load data using optimize/dataio.py
+    dataset = TracksDataset(filename=config.input_file, ntrack=config.data_sz, max_nbatch=max_nbatch, seed=config.data_seed, random_ntrack=config.random_ntrack, 
+                            track_len_sel=config.track_len_sel, max_abs_costheta_sel=config.max_abs_costheta_sel, min_abs_segz_sel=config.min_abs_segz_sel, track_z_bound=config.track_z_bound, max_batch_len=config.max_batch_len, print_input=config.print_input,
+                            preload=config.preload)
+
+    batch_sz = config.batch_sz
+    if config.max_batch_len is not None and batch_sz != 1:
+        logger.warning("Need batch size == 1 for splitting in dx chunks. Setting now...")
+        batch_sz = 1
+    
+    # set torch dataloader object
     tracks_dataloader = DataLoader(dataset,
-                                  shuffle=config.data_shuffle, 
-                                  batch_size=config.batch_sz,
-                                  pin_memory=True, num_workers=config.num_workers)
+                                   shuffle=config.data_shuffle, batch_size=batch_sz,
+                                   pin_memory=True, num_workers=config.num_workers)
+    # initialize simulation
+    #
     # For readout noise: no_noise overrides if explicitly set to True. Otherwise, turn on noise
     # individually for target and guess
-    param_fit = ParamFitter(config.param_list, dataset.get_track_fields(),
+    param_list = make_param_list(config)
+    param_fit = ParamFitter(param_list, dataset.get_track_fields(),
                             track_chunk=config.track_chunk, pixel_chunk=config.pixel_chunk,
                             detector_props=config.detector_props, pixel_layouts=config.pixel_layouts,
-                            load_checkpoint=config.load_checkpoint, lr=config.lr,
+                            load_checkpoint=config.load_checkpoint, lr=config.lr, 
                             readout_noise_target=(not config.no_noise) and (not config.no_noise_target),
-                            readout_noise_guess=(not config.no_noise) and (not config.no_noise_guess))
-
+                            readout_noise_guess=(not config.no_noise) and (not config.no_noise_guess),
+                            out_label=config.out_label, norm_scheme=config.norm_scheme, max_clip_norm_val=config.max_clip_norm_val,
+                            fit_diffs=config.fit_diffs, optimizer_fn=config.optimizer_fn,
+                            lr_scheduler=config.lr_scheduler, lr_kw=config.lr_kw,
+                            no_adc=config.no_adc, loss_fn=config.loss_fn, shift_no_fit=config.shift_no_fit,
+                            link_vdrift_eField=config.link_vdrift_eField, batch_memory=config.batch_memory, skip_pixels=config.skip_pixels,
+                            set_target_vals=config.set_target_vals, vary_init=config.vary_init, seed_init=config.seed_init,
+                            config = config)
     param_fit.make_target_sim(seed=config.seed)
-    landscape, fname = param_fit.loss_scan_batch(tracks_dataloader, param_range=config.param_range, n_steps=config.n_steps, shuffle=config.data_shuffle, save_freq=config.save_freq)
 
-    if config.plot:
-        plt.plot(landscape['param_vals'], landscape['losses'])
-        y_range = max(landscape['losses']) - min(landscape['losses'])
-        x_range = max(landscape['param_vals']) - min(landscape['param_vals'])
-        lr=0.02*x_range/(max(landscape['grads']))
-        for i in range(len(landscape['param_vals'])):
-            plt.arrow(landscape['param_vals'][i], landscape['losses'][i], -lr*landscape['grads'][i], 0, 
-                      width=0.01*y_range, head_width=0.05*y_range, 
-                      head_length=0.01*x_range)
-        plt.xlabel(landscape['param'])
-        plt.ylabel('Loss')
-        plt.tight_layout()
-        plt.savefig(fname+".pdf")
-        plt.show()
+    losses_only = False
+    # just scan for losses per batch without updating parameters?
+    if losses_only:
+        landscape, fname = param_fit.scan_batch_loss(tracks_dataloader, shuffle=False, save_freq=10, print_freq=1,
+                                                     seed=config.seed, data_seed=config.data_seed, seed_init=config.seed_init)
+        print('Saved initial losses to',fname)
+    else:
+        # old scan for losses and print gradient
+        landscape, fname = param_fit.loss_scan_batch(tracks_dataloader, shuffle=False, save_freq=5, print_freq=1)
+        if config.plot:
+            plt.plot(landscape['param_vals'], landscape['losses'])
+            y_range = max(landscape['losses']) - min(landscape['losses'])
+            x_range = max(landscape['param_vals']) - min(landscape['param_vals'])
+            lr=0.02*x_range/(max(landscape['grads']))
+            for i in range(len(landscape['param_vals'])):
+                plt.arrow(landscape['param_vals'][i], landscape['losses'][i], -lr*landscape['grads'][i], 0, 
+                            width=0.01*y_range, head_width=0.05*y_range, 
+                            head_length=0.01*x_range)
+            plt.xlabel(landscape['param'])
+            plt.ylabel('Loss')
+            plt.tight_layout()
+            plt.savefig(fname+".pdf")
+            plt.show()
 
     return 0, 'Fitting successful'
 
@@ -68,7 +123,7 @@ if __name__ == '__main__':
                         help='The number of worker threads to use for the dataloader.')
     parser.add_argument("--lr", dest="lr", default=1e1, type=float,
                         help="Learning rate -- used for all params")
-    parser.add_argument("--batch_sz", dest="batch_sz", default=2, type=int,
+    parser.add_argument("--batch_sz", dest="batch_sz", default=1, type=int,
                         help="Batch size for fitting (tracks).")
     parser.add_argument("--epochs", dest="epochs", default=100, type=int,
                         help="Number of epochs")
@@ -76,14 +131,12 @@ if __name__ == '__main__':
                         help="Random seed for target construction")
     parser.add_argument("--data_seed", dest="data_seed", default=3, type=int,
                         help="Random seed for data picking if not using the whole set")
-    parser.add_argument("--data_sz", dest="data_sz", default=5, type=int,
-                        help="data size for fitting (number of tracks)")
-    parser.add_argument("--param_range", dest="param_range", default=None, nargs="+", type=float,
-                        help="Param range for loss landscape")
-    parser.add_argument("--n_steps", dest="n_steps", default=10, type=int,
-                        help="Number of steps for loss landscape")
-    parser.add_argument("--plot", dest="plot", default=False, action="store_true",
-                        help="Makes landscape plot with arrows pointing in -grad direction")
+    parser.add_argument("--seed-init", dest="seed_init", default=30, type=int,
+                        help="Random seed for initial condition. Only used if --vary-init is passed.")
+    parser.add_argument("--vary-init", dest="vary_init", default=False, action="store_true",
+                        help="Randomly sample initial guess (vs starting at nominal value)")
+    parser.add_argument("--data_sz", dest="data_sz", default=None, type=int,
+                        help="Data size for fitting (number of tracks); input negative values to run on the whole dataset")
     parser.add_argument("--no-noise", dest="no_noise", default=False, action="store_true",
                         help="Flag to turn off readout noise (both target and guess)")
     parser.add_argument("--no-noise-target", dest="no_noise_target", default=False, action="store_true",
@@ -92,13 +145,64 @@ if __name__ == '__main__':
                         help="Flag to turn off readout noise (just guess, target has noise)")
     parser.add_argument("--data_shuffle", dest="data_shuffle", default=False, action="store_true",
                         help="Flag of data shuffling")
-    parser.add_argument("--save_freq", dest="save_freq", default=5, type=int,
+    parser.add_argument("--save_freq", dest="save_freq", default=10, type=int,
                         help="Save frequency of the result")
     parser.add_argument("--random_ntrack", dest="random_ntrack", default=False, action="store_true",
                         help="Flag of whether sampling the tracks randomly or sequentially")
-    parser.add_argument("--track_zlen_sel", dest="track_zlen_sel", default=30., type=float,
-                        help="Track selection requirement on the z expansion (drift axis)")
-
+    parser.add_argument("--track_len_sel", dest="track_len_sel", default=2., type=float,
+                        help="Track selection requirement on track length.")
+    parser.add_argument("--max_abs_costheta_sel", dest="max_abs_costheta_sel", default=0.966, type=float,
+                        help="Theta is the angle of track wrt to the z axis. Remove tracks which are very colinear with z.")
+    parser.add_argument("--min_abs_segz_sel", dest="min_abs_segz_sel", default=15., type=float,
+                        help="Remove track segments that are close to the cathode.")
+    parser.add_argument("--track_z_bound", dest="track_z_bound", default=28., type=float,
+                        help="Set z bound to keep healthy set of tracks")
+    parser.add_argument("--out_label", dest="out_label", default="",
+                        help="Label for output pkl file")
+    parser.add_argument("--fixed_range", dest="fixed_range", default=None, type=float,
+                        help="Construct target by sampling in a certain range (fraction of nominal)")
+    parser.add_argument("--norm_scheme", dest="norm_scheme", default="divide",
+                        help="Normalization scheme to use for params. Right now, divide (by nom) and standard (subtract mean, div by variance)")
+    parser.add_argument("--max_clip_norm_val", dest="max_clip_norm_val", default=None, type=float,
+                        help="If passed, does gradient clipping (norm)")
+    parser.add_argument("--fit_diffs", dest="fit_diffs", default=False, action="store_true",
+                        help="Turns on fitting of differences rather than direct fitting of values")
+    parser.add_argument("--optimizer_fn", dest="optimizer_fn", default="Adam",
+                        help="Choose optimizer function (here Adam vs SGD")
+    parser.add_argument("--lr_scheduler", dest="lr_scheduler", default=None,
+                        help="Schedule learning rate, e.g. ExponentialLR")
+    parser.add_argument("--lr_kw", dest="lr_kw", default=None, type=json.loads,
+                        help="kwargs for learning rate scheduler, as string dict")
+    parser.add_argument("--no_adc", dest="no_adc", default=False, action="store_true",
+                        help="Don't include ADC in loss (e.g. for vdrift)")
+    parser.add_argument("--iterations", dest="iterations", default=None, type=int,
+                        help="Number of iterations to run. Overrides epochs.")
+    parser.add_argument("--loss_fn", dest="loss_fn", default=None,
+                        help="Loss function to use. Named options are SDTW and space_match.")
+    parser.add_argument("--max_batch_len", dest="max_batch_len", default=None, type=float,
+                        help="Max dx [cm] per batch. If passed, will add tracks to batch until overflow, splitting where needed")
+    parser.add_argument("--max_nbatch", dest="max_nbatch", default=None, type=int,
+                        help="Upper number of different batches taken from the data, given the max_batch_len. Overrides data_sz.")
+    parser.add_argument("--print_input", dest="print_input", default=False, action="store_true",
+                        help="print the event and track id per batch.")
+    parser.add_argument("--shift-no-fit", dest="shift_no_fit", default=[], nargs="+", 
+                        help="Set of params to shift in target sim without fitting them (robustness/separability check).")
+    parser.add_argument("--set-target-vals", dest="set_target_vals", default=[], nargs="+", 
+                        help="Explicitly set values of target. Syntax is <param1> <val1> <param2> <val2>...")
+    parser.add_argument("--link-vdrift-eField", dest="link_vdrift_eField", default=False, action="store_true",
+                        help="Link vdrift and eField in fitting")
+    parser.add_argument("--batch_memory", dest="batch_memory", type=int, default=None,
+                        help="Optimize the pixel chunk size to reach the specified GPU memory per batch, in MiB")
+    parser.add_argument("--skip_pixels", dest="skip_pixels", default=False, action="store_true",
+                        help="Iterating only over the pixels of each track (no cartesian product of all pixels x all tracks)")
+    parser.add_argument("--preload", dest="preload", default=False, action="store_true", 
+                        help="If input file contains tracks already cut to dataio standards")
+    parser.add_argument("--param_range", dest="param_range", default=None, nargs="+", type=float,
+                        help="Param range for loss landscape")
+    parser.add_argument("--n_steps", dest="n_steps", default=10, type=int,
+                        help="Number of steps for loss landscape")
+    parser.add_argument("--plot", dest="plot", default=False, action="store_true",
+                        help="Makes landscape plot with arrows pointing in -grad direction")
                         
     try:
         args = parser.parse_args()

--- a/optimize/scripts/make_dataio_cut.sh
+++ b/optimize/scripts/make_dataio_cut.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#SBATCH --partition=ampere
+#SBATCH --job-name=dataio-cut-larndsim
+#SBATCH --output=output-%j.txt --error=output-%j.txt
+#SBATCH --ntasks-per-node=1
+#SBATCH --gpus-per-node=a100:1
+#SBATCH --cpus-per-task=1
+#SBATCH --time=12:00:00
+
+# muon input file
+INPUT_FILE=/fs/ddn//sdf/group/neutrino/cyifan/muon-sim/fake_data_S1/edepsim-output.h5
+# proton input file
+INPUT_FILE=/fs/ddn/sdf/group/neutrino/cyifan/muon-sim/larndsim_output/f1_1000_p_high_KE/edepsim-output.h5
+
+SIF_FILE=/sdf/group/neutrino/images/larndsim_latest.sif
+MIN_DEDX=10
+OUT_LABEL=proton_no_nuclei_min${MIN_DEDX}
+#change cutting min to max with --max
+# dataio values
+max_abs_costheta_sel=0.966; min_abs_segz_sel=15; track_z_bound=28; track_len_sel=2
+
+
+singularity exec --bind /fs --nv ${SIF_FILE} \
+  python3 make_dataio_cut.py ${INPUT_FILE} \
+  --output ${OUT_LABEL} \
+  --threshold ${MIN_DEDX} \
+  --max_abs_costheta_sel ${max_abs_costheta_sel} \
+  --min_abs_segz_sel ${min_abs_segz_sel} \
+  --track_z_bound ${track_z_bound} \
+  --track_len_sel ${track_len_sel} \
+
+
+
+  
+  
+

--- a/optimize/scripts/sbatch_loss-landscape.sh
+++ b/optimize/scripts/sbatch_loss-landscape.sh
@@ -1,32 +1,31 @@
 #!/bin/bash
 #SBATCH --partition=ampere
-#SBATCH --job-name=larndsim-fit
+#SBATCH --job-name=min5-loss-landscape-larndsim
 #SBATCH --output=output-%j.txt --error=output-%j.txt
 #SBATCH --ntasks-per-node=1
 #SBATCH --gpus-per-node=a100:1
 #SBATCH --cpus-per-task=1
-#SBATCH --time=72:00:00
+#SBATCH --time=36:00:00
 #SBATCH --array=1,2,3,4,5
 
 seed=$SLURM_ARRAY_TASK_ID
 seed_init=$SLURM_ARRAY_TASK_ID
-data_seed=${seed}
+data_seed=6
 
-#INPUT_FILE=/sdf/group/neutrino/cyifan/muon-sim/fake_data_S1/edepsim-output.h5
 # INPUT_FILE=/sdf/home/b/bkroul/l-sim/h5/proton_no_nuclei.h5
-INPUT_FILE=/sdf/home/b/bkroul/l-sim/h5/proton_max-dEdx2.h5
-#INPUT_FILE=/sdf/home/b/bkroul/l-sim/h5/proton_min-dEdx5.h5
+# INPUT_FILE=/sdf/home/b/bkroul/l-sim/h5/proton_max-dEdx2.h5
+INPUT_FILE=/sdf/home/b/bkroul/l-sim/h5/proton_min-dEdx5.h5
+label=proton_min-5_loss_i=seed${seed}_dtseed${data_seed}
 
 SIF_FILE=/sdf/group/neutrino/images/larndsim_latest.sif
 PARAM=/sdf/home/b/bkroul/larnd-sim/optimize/scripts/param_list.yaml
 
 max_abs_costheta_sel=0.966; min_abs_segz_sel=15; track_z_bound=28; track_len_sel=2; # dataio values
 batch_memory=32768; max_grad_clip=1 
-
-label=proton_max-2_i=dt=seed${seed}__btch${batch_memory}MB
+# label=proton_noise_multipar_adaptive_chunk_linkvE_adam_SDTW_gradclip1_gamma0-95_costheta${max_abs_costheta_sel}_segz${min_abs_segz_sel}_z_bound${track_z_bound}_len${track_len_sel}_dtseed${seed}_iseed${seed_init}__btch${batch_memory}MB
 
 singularity exec -B /sdf --nv --bind /fs ${SIF_FILE} \
-  python3 -m optimize.example_run \
+  python3 -m optimize.loss_landscape \
     --preload \
     --vary-init \
     --seed-init ${seed_init} \


### PR DESCRIPTION
1. `Make_plots.py` is a pretty versatile script that can plot a bunch of stuff, I've updated the end of the readme to reflect that.
2. Can now skip the cutting tracks part of dataio, which takes a few hours, by cutting tracks from the edep-sim input .h5 file to begin with. 
- Created `make_dataio_cut.py` and `optimize/scripts/make_dataio_cut.sh` to make a dataio cut from existing .h5 data, with mean track dEdx energy thresholding. 
3. A new updated `loss_scan_batch function` with `optimize/scripts/sbatch_loss-landscape.sh` that only scans the initial batches for losses without advancing the parameters.